### PR TITLE
feat: initial commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,100 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '31 0 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: go
+          build-mode: autobuild
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,0 +1,27 @@
+name: Lint and Test
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+      - run: task deps
+      - run: task lint
+      - run: task test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+
+## [v1.0.0] - 2025-09-20
+
+### Added
+
+- Initial release

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, PedramKTB
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,162 @@
+# netx
+
+Small, focused extensions to Go's "net" standard library.
+
+This library provides a few composable building blocks that integrate with standard `net.Conn` and `net.Listener` types without introducing heavy abstractions.
+
+- Buffered connections: `NewBufConn` adds buffered read/write with explicit `Flush`.
+- Framed connections: `NewFramedConn` adds a simple 4‑byte length‑prefixed frame protocol.
+- Connection router/server: `Server[ID]` accepts on a listener and routes new conns to handlers you register at runtime.
+- Tunneling: `Tun` and `TunMaster[ID]` wire two connections together for bidirectional relay (useful to bridge UDP over a framed TCP stream, add TLS, etc.).
+
+## Install
+
+```bash
+go get github.com/pedramktb/go-netx@latest
+```
+
+Import as:
+
+```go
+import netx "github.com/pedramktb/go-netx"
+```
+
+## Quick examples
+
+### Buffered connection (net.Conn + Flush)
+
+```go
+c, _ := net.Dial("tcp", addr)
+bc := netx.NewBufConn(c, netx.WithBufReaderSize(8<<10), netx.WithBufWriterSize(8<<10))
+
+_, _ = bc.Write([]byte("hello"))
+_ = bc.Flush() // ensure data is written now
+```
+
+Notes:
+
+- `NewBufConn` returns a type that implements `net.Conn` plus `Flush() error`.
+- `Close()` will attempt to `Flush()` and close, returning a joined error if any.
+
+### Framed connection (length‑prefixed)
+
+```go
+rawClient, rawServer := net.Pipe()
+defer rawClient.Close(); defer rawServer.Close()
+
+client := netx.NewFramedConn(rawClient)                 // default max frame size 16KiB
+server := netx.NewFramedConn(rawServer, netx.WithMaxFrameSize(64<<10))
+
+msg := []byte("hello frame")
+_, _ = client.Write(msg) // sends a 4‑byte big‑endian length header then payload
+
+buf := make([]byte, len(msg))
+_, _ = io.ReadFull(server, buf) // reads exactly one frame (may deliver across multiple Read calls)
+```
+
+Notes:
+
+- Each `Write(p)` sends one frame. Empty frames are allowed and read as `n=0, err=nil`.
+- If an incoming frame exceeds `maxFrameSize`, `Read` returns `ErrFrameTooLarge`.
+- If the underlying conn also supports `Flush` (e.g., `BufConn`), `Write` flushes to coalesce header+payload.
+
+### Runtime‑routable server
+
+Register handlers keyed by an ID (any comparable type). Each handler decides if it matches an incoming connection and returns an `io.Closer` to track (often the conn itself or a wrapped version).
+
+```go
+var s netx.Server[string]
+
+// Route A: TLS connections
+s.SetRoute("tls", func(ctx context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+	if _, ok := conn.(interface{ ConnectionState() tls.ConnectionState }); !ok {
+		return false, nil
+	}
+	// handle TLS conn; call closed() when the connection is fully done
+	go func() { /* ... */ ; closed() }()
+	return true, conn
+})
+
+// Route B: plain connections (fallback)
+s.SetRoute("plain", func(ctx context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+	if _, ok := conn.(interface{ ConnectionState() tls.ConnectionState }); ok {
+		return false, nil
+	}
+	go func() { /* ... */ ; closed() }()
+	return true, conn
+})
+
+ln, _ := net.Listen("tcp", ":8080")
+go s.Serve(context.Background(), ln)
+
+// Hot‑swap or remove routes at runtime
+s.SetRoute("plain", newHandler)
+s.RemoveRoute("tls")
+
+// Graceful shutdown
+ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+defer cancel()
+_ = s.Shutdown(ctx) // waits for tracked connections or force‑closes on deadline
+```
+
+Handler contract:
+
+- Return `(matched=false, _ )` quickly if the connection is not yours; the server will try the next route.
+- If you take ownership, return `(true, closer)`. Use `closed()` exactly once when you are logically done so the server stops tracking it.
+- If you return `nil` for the closer, the server will track the original `conn`.
+- `Close()` immediately stops accepting and closes tracked connections. `Shutdown(ctx)` stops accepting and waits for tracked connections until `ctx` is done, then force‑closes.
+
+### Tunneling and UDP over TCP
+
+`Tun` relays bytes bidirectionally between two endpoints. `TunMaster[ID]` builds on `Server[ID]` to create tunnels from accepted conns.
+
+Bridge UDP over a framed TCP stream:
+
+```go
+// Server side: accept a TCP stream, frame it, and relay to a UDP socket
+var tm netx.TunMaster[string]
+tm.SetRoute("udp-over-tcp", func(ctx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
+	framed := netx.NewFramedConn(conn)
+	udpConn, _ := net.DialUDP("udp", nil, serverUDPAddr)
+	return true, ctx, netx.Tun{Conn: framed, Peer: udpConn, BufferSize: 64 << 10}
+})
+
+ln, _ := net.Listen("tcp", ":9000")
+go tm.Serve(context.Background(), ln)
+```
+
+Notes:
+
+- `Tun.Relay(ctx)` runs two half‑duplex copies until either side closes; `Close()` shuts both sides.
+- `BufferSize` controls the copy buffer (default 32KiB).
+- `TunMaster.SetRoute` starts `Relay` in a goroutine and calls the server's `closed()` when finished; it also logs tunnel start/close using the configured `Logger`.
+
+## Logging
+
+You can plug any logger that implements the simple `Logger` interface:
+
+```go
+type Logger interface {
+	DebugContext(ctx context.Context, msg string, args ...any)
+	InfoContext(ctx context.Context, msg string, args ...any)
+	WarnContext(ctx context.Context, msg string, args ...any)
+	ErrorContext(ctx context.Context, msg string, args ...any)
+}
+```
+
+If `Logger` is nil, the server/tunnel use `slog.Default()`.
+
+## Design notes and guarantees
+
+- All wrappers implement `net.Conn` where applicable to remain drop‑in.
+- Server routes use copy‑on‑write updates; `SetRoute`/`RemoveRoute` are safe to call concurrently.
+- Unhandled connections are dropped immediately after all routes decline.
+- `Shutdown(ctx)` will close listeners, then wait for tracked connections until `ctx` is done, after which remaining connections are force‑closed.
+
+## Testing
+
+The repository includes unit and end‑to‑end tests (UDP over TCP, TLS routing, graceful shutdown). Run:
+
+```bash
+go test ./...
+```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+tasks:
+  default:
+   cmds:
+      - task --list
+
+  deps:
+    desc: Install dependencies
+    cmds:
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      - go mod download
+
+  lint:
+    desc: Run linter
+    cmds:
+      - golangci-lint run
+
+  test:
+    desc: Run tests
+    cmds:
+      - go test ./...

--- a/buffered_conn.go
+++ b/buffered_conn.go
@@ -1,0 +1,73 @@
+package netx
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"time"
+)
+
+type BufConn interface {
+	net.Conn
+	Flush() error
+}
+
+type bufConn struct {
+	bc net.Conn
+	br *bufio.Reader
+	bw *bufio.Writer
+}
+
+type bufConnOption func(*bufConn)
+
+func WithBufWriterSize(size int) bufConnOption {
+	return func(bc *bufConn) {
+		bc.bw = bufio.NewWriterSize(bc.bc, size)
+	}
+}
+
+func WithBufReaderSize(size int) bufConnOption {
+	return func(bc *bufConn) {
+		bc.br = bufio.NewReaderSize(bc.bc, size)
+	}
+}
+
+// NewBufConn wraps a net.Conn with buffered reader and writer.
+// By default, the buffer size is 4KB. Use WithBufWriterSize and WithBufReaderSize to customize the sizes.
+func NewBufConn(c net.Conn, opts ...bufConnOption) BufConn {
+	bc := &bufConn{
+		bc: c,
+		br: bufio.NewReader(c),
+		bw: bufio.NewWriter(c),
+	}
+	for _, opt := range opts {
+		opt(bc)
+	}
+	return bc
+}
+
+func (c *bufConn) Read(p []byte) (int, error)  { return c.br.Read(p) }
+func (c *bufConn) Write(p []byte) (int, error) { return c.bw.Write(p) }
+func (c *bufConn) Close() error {
+	// Attempt to flush; collect both flush and close errors.
+	// Even if flush fails, still attempt to close the underlying conn.
+	var err error
+	if c.bw != nil {
+		if fErr := c.bw.Flush(); fErr != nil {
+			err = errors.Join(err, fErr)
+		}
+	}
+	if c.bc != nil {
+		if cErr := c.bc.Close(); cErr != nil {
+			err = errors.Join(err, cErr)
+		}
+	}
+	return err
+}
+func (c *bufConn) LocalAddr() net.Addr                { return c.bc.LocalAddr() }
+func (c *bufConn) RemoteAddr() net.Addr               { return c.bc.RemoteAddr() }
+func (c *bufConn) SetDeadline(t time.Time) error      { return c.bc.SetDeadline(t) }
+func (c *bufConn) SetReadDeadline(t time.Time) error  { return c.bc.SetReadDeadline(t) }
+func (c *bufConn) SetWriteDeadline(t time.Time) error { return c.bc.SetWriteDeadline(t) }
+
+func (c *bufConn) Flush() error { return c.bw.Flush() }

--- a/buffered_conn_test.go
+++ b/buffered_conn_test.go
@@ -1,0 +1,73 @@
+package netx_test
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	netx "github.com/pedramktb/go-netx"
+)
+
+func TestBufConnReadWrite(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	t.Cleanup(func() { _ = clientRaw.Close(); _ = serverRaw.Close() })
+
+	c := netx.NewBufConn(clientRaw)
+	s := netx.NewBufConn(serverRaw)
+
+	// write from client to server
+	msg := []byte("hello buffered world")
+	if _, err := c.Write(msg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Data should be buffered until Flush.
+	// We can't access internal buffers from an external package; ensure that
+	// before Flush, a concurrent reader doesn't receive data, and after Flush it does.
+	got := make([]byte, len(msg))
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(s, got)
+		done <- err
+	}()
+	// Give the goroutine a moment; it should not complete until flush.
+	select {
+	case <-done:
+		t.Fatalf("read finished before flush; expected buffering")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := c.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("readfull: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for read")
+	}
+	if !bytes.Equal(got, msg) {
+		t.Fatalf("mismatch: got %q want %q", got, msg)
+	}
+}
+
+func TestBufConnCustomSizes(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	t.Cleanup(func() { _ = clientRaw.Close(); _ = serverRaw.Close() })
+
+	c := netx.NewBufConn(clientRaw, netx.WithBufReaderSize(128), netx.WithBufWriterSize(256))
+	s := netx.NewBufConn(serverRaw, netx.WithBufReaderSize(128), netx.WithBufWriterSize(256))
+
+	// roundtrip
+	data := bytes.Repeat([]byte("a"), 1024)
+	go func() { _, _ = c.Write(data); _ = c.Flush() }()
+	got := make([]byte, len(data))
+	if _, err := io.ReadFull(s, got); err != nil {
+		t.Fatalf("readfull: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("mismatch")
+	}
+}

--- a/framed_conn.go
+++ b/framed_conn.go
@@ -1,0 +1,112 @@
+package netx
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+var ErrFrameTooLarge = errors.New("framedConn: frame too large")
+
+type framedConn struct {
+	bc           net.Conn
+	maxFrameSize int
+	pending      []byte
+	rmu, wmu     sync.Mutex
+}
+
+type framedConnOption func(*framedConn)
+
+func WithMaxFrameSize(size int) framedConnOption {
+	return func(c *framedConn) {
+		c.maxFrameSize = size
+	}
+}
+
+// NewFramedConn wraps a net.Conn with a simple length-prefixed framing protocol.
+// Each frame is prefixed with a 4-byte big-endian unsigned integer indicating the length of the frame.
+// If the frame size exceeds maxFrameSize, Read will return ErrFrameTooLarge.
+// The default maxFrameSize is 16KB.
+func NewFramedConn(c net.Conn, opts ...framedConnOption) net.Conn {
+	fc := &framedConn{
+		bc:           c,
+		maxFrameSize: 1 << 14, // 16KB default max frame size
+	}
+	for _, opt := range opts {
+		opt(fc)
+	}
+	return fc
+}
+
+// Read returns at most one frame's bytes; large frames are delivered across multiple Reads.
+func (c *framedConn) Read(p []byte) (int, error) {
+	c.rmu.Lock()
+	defer c.rmu.Unlock()
+
+	if len(c.pending) > 0 {
+		n := copy(p, c.pending)
+		c.pending = c.pending[n:]
+		return n, nil
+	}
+
+	var hdr [4]byte
+	if _, err := io.ReadFull(c.bc, hdr[:]); err != nil {
+		return 0, err
+	}
+	n := int(binary.BigEndian.Uint32(hdr[:]))
+	if n > c.maxFrameSize {
+		return 0, ErrFrameTooLarge
+	}
+	if n == 0 {
+		// Deliver empty frame as a zero-length read to allow keep-alives.
+		return 0, nil
+	}
+
+	if len(p) >= n {
+		_, err := io.ReadFull(c.bc, p[:n])
+		return n, err
+	}
+
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(c.bc, buf); err != nil {
+		return 0, err
+	}
+	w := copy(p, buf)
+	c.pending = buf[w:]
+	return w, nil
+}
+
+// Write sends p as a single frame.
+func (c *framedConn) Write(p []byte) (int, error) {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(p)))
+	if _, err := c.bc.Write(hdr[:]); err != nil {
+		return 0, err
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if _, err := c.bc.Write(p); err != nil {
+		return 0, err
+	}
+	// If the underlying layer is buffered and implements Flush, flush now to coalesce header+payload.
+	if fw, ok := c.bc.(BufConn); ok {
+		if err := fw.Flush(); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+func (c *framedConn) Close() error                       { return c.bc.Close() }
+func (c *framedConn) LocalAddr() net.Addr                { return c.bc.LocalAddr() }
+func (c *framedConn) RemoteAddr() net.Addr               { return c.bc.RemoteAddr() }
+func (c *framedConn) SetDeadline(t time.Time) error      { return c.bc.SetDeadline(t) }
+func (c *framedConn) SetReadDeadline(t time.Time) error  { return c.bc.SetReadDeadline(t) }
+func (c *framedConn) SetWriteDeadline(t time.Time) error { return c.bc.SetWriteDeadline(t) }

--- a/framed_conn_test.go
+++ b/framed_conn_test.go
@@ -1,0 +1,177 @@
+package netx_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	netx "github.com/pedramktb/go-netx"
+)
+
+// helper to write a frame to a raw conn
+func writeFrame(t *testing.T, c net.Conn, payload []byte) {
+	t.Helper()
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload)))
+	if _, err := c.Write(hdr[:]); err != nil {
+		t.Fatalf("write hdr: %v", err)
+	}
+	if len(payload) > 0 {
+		if _, err := c.Write(payload); err != nil {
+			t.Fatalf("write body: %v", err)
+		}
+	}
+}
+
+func TestFramedConnSimple(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	t.Cleanup(func() { _ = clientRaw.Close(); _ = serverRaw.Close() })
+
+	fcClient := netx.NewFramedConn(clientRaw)
+	fcServer := netx.NewFramedConn(serverRaw)
+
+	// send one frame
+	msg := []byte("hello frame")
+	got := make([]byte, len(msg))
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(fcServer, got)
+		done <- err
+	}()
+	time.Sleep(10 * time.Millisecond)
+	if _, err := fcClient.Write(msg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("readfull: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout")
+	}
+	if !bytes.Equal(got, msg) {
+		t.Fatalf("mismatch")
+	}
+}
+
+func TestFramedConnPartialRead(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	t.Cleanup(func() { _ = clientRaw.Close(); _ = serverRaw.Close() })
+
+	fcClient := netx.NewFramedConn(clientRaw)
+	fcServer := netx.NewFramedConn(serverRaw)
+
+	data := bytes.Repeat([]byte("x"), 1024)
+	// Start reader first to avoid pipe deadlock
+	first := make([]byte, 100)
+	type res struct {
+		n   int
+		err error
+	}
+	done1 := make(chan res, 1)
+	go func() {
+		n1, err := fcServer.Read(first)
+		done1 <- res{n: n1, err: err}
+	}()
+	time.Sleep(10 * time.Millisecond)
+	if _, err := fcClient.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	select {
+	case r := <-done1:
+		if r.err != nil || r.n != 100 {
+			t.Fatalf("read1 n=%d err=%v", r.n, r.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout first read")
+	}
+
+	// Now read the remainder
+	rest := make([]byte, len(data)-len(first))
+	n2, err := io.ReadFull(fcServer, rest)
+	if err != nil {
+		t.Fatalf("read2: %v", err)
+	}
+	if n2 != len(rest) {
+		t.Fatalf("n2=%d", n2)
+	}
+}
+
+func TestFramedConnDeliversEmptyFrames(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	t.Cleanup(func() { _ = clientRaw.Close(); _ = serverRaw.Close() })
+
+	fcServer := netx.NewFramedConn(serverRaw)
+
+	// write two empty frames and then a payload on the client side using raw writer
+	payload := []byte("data")
+	doneWrite := make(chan struct{})
+	go func() {
+		writeFrame(t, clientRaw, nil)
+		writeFrame(t, clientRaw, []byte{})
+		writeFrame(t, clientRaw, payload)
+		close(doneWrite)
+	}()
+
+	// First empty frame should yield 0, nil
+	buf := make([]byte, 8)
+	n, err := fcServer.Read(buf)
+	if err != nil || n != 0 {
+		t.Fatalf("empty1 n=%d err=%v", n, err)
+	}
+	// Second empty frame should also yield 0, nil
+	n, err = fcServer.Read(buf)
+	if err != nil || n != 0 {
+		t.Fatalf("empty2 n=%d err=%v", n, err)
+	}
+	// Then the payload
+	n, err = fcServer.Read(buf)
+	if err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if n != len(payload) || !bytes.Equal(buf[:n], payload) {
+		t.Fatalf("unexpected payload: %q", buf[:n])
+	}
+	select {
+	case <-doneWrite:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("writer blocked")
+	}
+}
+
+func TestFramedConnMaxSize(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	t.Cleanup(func() { _ = clientRaw.Close(); _ = serverRaw.Close() })
+
+	// Set small max frame size
+	fcServer := netx.NewFramedConn(serverRaw, netx.WithMaxFrameSize(32))
+
+	// Start a read and only send an oversized header so the reader errors
+	buf := make([]byte, 10)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := fcServer.Read(buf)
+		errCh <- err
+	}()
+	time.Sleep(10 * time.Millisecond)
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(64)) // larger than max 32
+	if _, err := clientRaw.Write(hdr[:]); err != nil {
+		t.Fatalf("write hdr: %v", err)
+	}
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatalf("expected ErrFrameTooLarge")
+		}
+		if err != netx.ErrFrameTooLarge {
+			t.Fatalf("got err=%v want ErrFrameTooLarge", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pedramktb/go-netx
+
+go 1.25.1

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,10 @@
+package netx
+
+import "context"
+
+type Logger interface {
+	DebugContext(ctx context.Context, msg string, args ...any)
+	InfoContext(ctx context.Context, msg string, args ...any)
+	WarnContext(ctx context.Context, msg string, args ...any)
+	ErrorContext(ctx context.Context, msg string, args ...any)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,44 @@
+package netx_test
+
+import (
+	"context"
+	"log"
+	"sync"
+)
+
+// memLogger captures logs for assertion in tests
+type memLogger struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+func (l *memLogger) append(level, msg string) {
+	l.mu.Lock()
+	l.entries = append(l.entries, level+": "+msg)
+	l.mu.Unlock()
+}
+
+func (l *memLogger) print(level, msg string, args ...any) {
+	if len(args) > 0 {
+		log.Printf("%s: %s %v", level, msg, args)
+	} else {
+		log.Printf("%s: %s", level, msg)
+	}
+}
+
+func (l *memLogger) DebugContext(ctx context.Context, msg string, args ...any) {
+	l.append("DEBUG", msg)
+	l.print("DEBUG", msg, args...)
+}
+func (l *memLogger) InfoContext(ctx context.Context, msg string, args ...any) {
+	l.append("INFO", msg)
+	l.print("INFO", msg, args...)
+}
+func (l *memLogger) WarnContext(ctx context.Context, msg string, args ...any) {
+	l.append("WARN", msg)
+	l.print("WARN", msg, args...)
+}
+func (l *memLogger) ErrorContext(ctx context.Context, msg string, args ...any) {
+	l.append("ERROR", msg)
+	l.print("ERROR", msg, args...)
+}

--- a/server.go
+++ b/server.go
@@ -1,0 +1,261 @@
+package netx
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	ErrServerClosed = errors.New("server is shutting down")
+)
+
+// Handler is a function that takes a base context, a net.Conn representing the incoming connection,
+// and a closed function that should be called when the user is done with the connection.
+// It returns a boolean indicating whether the connection matches the handler
+// and a wrappedConn server can continue using for closing them.
+//
+// You should implement Handler in a way that it returns true for connections that should be handled by this handler.
+// If the connection does not match, return false and nil wrappedConn. Do not call the closed function.
+// Matching should be handled early, as the server will simply try handlers to find a match.
+// The wrappedConn can be the same as the input conn, or a wrapped version of it (e.g. with TLS, obfuscation, etc).
+type Handler func(ctx context.Context, conn net.Conn, closed func()) (matched bool, wrappedConn io.Closer)
+
+// Server initially accepts no connections, since there are no initial handlers.
+// It's the duty of the caller to add handlers via SetRoute.
+// The generic ID type is used to identify different handlers, e.g. packet header, http path, remote address, username, etc.
+type Server[ID comparable] struct {
+	Logger Logger
+
+	// We use a copy-on-write pattern to allow fast handler lookup.
+	routes   atomic.Value
+	routesMu sync.Mutex
+
+	inShutdown atomic.Bool
+
+	mu sync.Mutex
+
+	listeners     map[net.Listener]struct{}
+	listenerGroup sync.WaitGroup
+
+	conns map[*io.Closer]struct{}
+}
+
+func (s *Server[ID]) Serve(ctx context.Context, listener net.Listener) error {
+	if s.Logger == nil {
+		s.Logger = slog.Default()
+	}
+
+	if !s.addListener(listener) {
+		return ErrServerClosed
+	}
+	defer s.removeListener(listener)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if s.shuttingDown() {
+				return ErrServerClosed
+			}
+			s.Logger.WarnContext(ctx, "error accepting connection", "error", err.Error())
+			continue
+		}
+		go s.route(ctx, conn)
+	}
+}
+
+// SetRoute sets a handler for a specific ID.
+// If a handler already exists for this ID, it will be replaced.
+// It does not close any existing connections that were created by the previous handler, but new connections will use the new handler.
+func (s *Server[ID]) SetRoute(id ID, handler Handler) {
+	s.routesMu.Lock()
+	defer s.routesMu.Unlock()
+	old, _ := s.routes.Load().([]route[ID])
+	// if there are no routes yet, initialize with the first one
+	if old == nil {
+		s.routes.Store([]route[ID]{{id: id, handler: handler}})
+		return
+	}
+	// check if we need to replace an existing route; always copy-on-write
+	for i, r := range old {
+		if r.id == id {
+			newRoutes := make([]route[ID], len(old))
+			copy(newRoutes, old)
+			newRoutes[i] = route[ID]{id: id, handler: handler}
+			s.routes.Store(newRoutes)
+			return
+		}
+	}
+	// append a new route by creating a new slice to avoid modifying shared backing array
+	newRoutes := make([]route[ID], len(old)+1)
+	copy(newRoutes, old)
+	newRoutes[len(old)] = route[ID]{id: id, handler: handler}
+	s.routes.Store(newRoutes)
+}
+
+// RemoveRoute removes a handler by its ID.
+// It does not close any existing connections that were created by this handler.
+func (s *Server[ID]) RemoveRoute(id ID) {
+	s.routesMu.Lock()
+	defer s.routesMu.Unlock()
+	routes, _ := s.routes.Load().([]route[ID])
+	if len(routes) == 0 {
+		return
+	}
+	// build a new slice excluding the id
+	newRoutes := make([]route[ID], 0, len(routes))
+	for _, r := range routes {
+		if r.id != id {
+			newRoutes = append(newRoutes, r)
+		}
+	}
+	s.routes.Store(newRoutes)
+}
+
+type route[ID comparable] struct {
+	id      ID
+	handler Handler
+}
+
+func (s *Server[ID]) route(ctx context.Context, conn net.Conn) {
+	routes, ok := s.routes.Load().([]route[ID])
+	if !ok {
+		_ = conn.Close()
+		s.Logger.DebugContext(ctx, "no routes configured, dropping connection", "addr", conn.RemoteAddr().String())
+		return
+	}
+	for _, r := range routes {
+		connCloser := io.Closer(conn)
+		var wConn *io.Closer = &connCloser
+		var ok bool
+		closeCooldown := make(chan struct{}, 1)
+		ok, connCloser = r.handler(ctx, conn, func() {
+			<-closeCooldown
+			s.mu.Lock()
+			delete(s.conns, wConn)
+			s.mu.Unlock()
+		})
+		if !ok {
+			continue
+		}
+		// Fallback to original conn if handler returned nil closer
+		if connCloser == nil {
+			connCloser = conn
+		}
+		s.mu.Lock()
+		if s.conns == nil {
+			s.conns = make(map[*io.Closer]struct{})
+		}
+		s.conns[wConn] = struct{}{}
+		s.mu.Unlock()
+		closeCooldown <- struct{}{}
+		return
+	}
+	_ = conn.Close() // make sure to close the connection if not already closed by the handler
+	s.Logger.DebugContext(ctx, "unhandled connection, dropping connection", "addr", conn.RemoteAddr().String())
+}
+
+func (s *Server[ID]) addListener(l net.Listener) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.listeners == nil {
+		s.listeners = make(map[net.Listener]struct{})
+	}
+	if s.shuttingDown() {
+		return false
+	}
+	s.listeners[l] = struct{}{}
+	s.listenerGroup.Add(1)
+	return true
+}
+
+func (s *Server[ID]) removeListener(l net.Listener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.listeners, l)
+	s.listenerGroup.Done()
+}
+
+func (s *Server[ID]) Close() error {
+	s.inShutdown.Store(true)
+
+	// First close listeners under lock
+	s.mu.Lock()
+	var err error
+	for l := range s.listeners {
+		if cErr := l.Close(); cErr != nil {
+			err = errors.Join(err, cErr)
+		}
+	}
+	s.mu.Unlock() // unlock before waiting to avoid deadlock
+
+	// Wait for Serve to remove all listeners
+	s.listenerGroup.Wait()
+
+	// Now close all active connections under lock
+	s.mu.Lock()
+	for c := range s.conns {
+		_ = (*c).Close()
+		delete(s.conns, c)
+	}
+	s.mu.Unlock()
+
+	return err
+}
+
+// Shutdown gracefully shuts down the server without interrupting active connections.
+// It stops accepting new connections and waits until all tracked connections finish
+// or the provided context is done. If the context is done before all connections
+// finish, Shutdown will force-close remaining connections and return the context error
+// joined with any listener close error.
+func (s *Server[ID]) Shutdown(ctx context.Context) error {
+	s.inShutdown.Store(true)
+
+	// Close listeners to stop accepting new connections
+	s.mu.Lock()
+	var err error
+	for l := range s.listeners {
+		if cErr := l.Close(); cErr != nil {
+			err = errors.Join(err, cErr)
+		}
+	}
+	s.mu.Unlock()
+
+	// Wait for Serve to remove all listeners
+	s.listenerGroup.Wait()
+
+	// Wait for active connections to finish, honoring context
+	// Ticker to avoid busy waiting
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		s.mu.Lock()
+		remaining := len(s.conns)
+		s.mu.Unlock()
+		if remaining == 0 {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			// Timeout/cancellation: force close remaining connections
+			s.mu.Lock()
+			for c := range s.conns {
+				_ = (*c).Close()
+				delete(s.conns, c)
+			}
+			s.mu.Unlock()
+			return errors.Join(err, ctx.Err())
+		case <-ticker.C:
+			// re-check
+		}
+	}
+}
+
+func (s *Server[ID]) shuttingDown() bool {
+	return s.inShutdown.Load()
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,395 @@
+package netx_test
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pedramktb/go-netx"
+)
+
+func TestRouteReplacement(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+	var s netx.Server[string]
+	s.Logger = logger
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(ctx, ln) }()
+
+	// First handler (will be replaced)
+	s.SetRoute("id", func(_ context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+		// Always match
+		_, _ = conn.Write([]byte("h1"))
+		_ = conn.Close()
+		closed()
+		return true, conn
+	})
+
+	c1, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial1: %v", err)
+	}
+	_ = c1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	b1 := make([]byte, 2)
+	if _, err := bufio.NewReader(c1).Read(b1); err != nil {
+		t.Fatalf("read1: %v", err)
+	}
+	if string(b1) != "h1" {
+		t.Fatalf("expected 'h1', got %q", string(b1))
+	}
+	_ = c1.Close()
+
+	// Replace with a new handler under the same ID
+	s.SetRoute("id", func(_ context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+		_, _ = conn.Write([]byte("h2"))
+		_ = conn.Close()
+		closed()
+		return true, conn
+	})
+
+	c2, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial2: %v", err)
+	}
+	_ = c2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	b2 := make([]byte, 2)
+	if _, err := bufio.NewReader(c2).Read(b2); err != nil {
+		t.Fatalf("read2: %v", err)
+	}
+	if string(b2) != "h2" {
+		t.Fatalf("expected 'h2', got %q", string(b2))
+	}
+	_ = c2.Close()
+
+	// Shutdown and ensure Serve returns ErrServerClosed
+	if err := s.Close(); err != nil && !errors.Is(err, netx.ErrServerClosed) {
+		t.Fatalf("server close: %v", err)
+	}
+	select {
+	case got := <-errCh:
+		if !errors.Is(got, netx.ErrServerClosed) {
+			t.Fatalf("serve returned %v, want ErrServerClosed", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("serve did not exit after Close()")
+	}
+}
+
+func TestRemoveRouteThenUnhandled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+	var s netx.Server[string]
+	s.Logger = logger
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(ctx, ln) }()
+
+	s.SetRoute("id", func(_ context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+		// This would match if present
+		return true, conn
+	})
+	s.RemoveRoute("id")
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Give some time for the server to process and drop the connection
+	_ = c.SetDeadline(time.Now().Add(500 * time.Millisecond))
+	// Expect read to hit EOF or error quickly because server drops immediately
+	buf := make([]byte, 1)
+	_, rErr := c.Read(buf)
+	if rErr == nil {
+		t.Fatalf("expected read error/EOF on unhandled connection, got nil")
+	}
+	_ = c.Close()
+
+	// Ensure log captured unhandled drop
+	time.Sleep(100 * time.Millisecond)
+	logger.mu.Lock()
+	found := false
+	for _, e := range logger.entries {
+		if e == "DEBUG: unhandled connection, dropping..." || e == "DEBUG: unhandled connection, dropping connection" || e == "DEBUG: no routes configured, dropping connection" {
+			found = true
+			break
+		}
+	}
+	logger.mu.Unlock()
+	if !found {
+		t.Fatalf("expected unhandled/no routes log entry, got: %#v", logger.entries)
+	}
+
+	// Cleanup
+	_ = s.Close()
+	select {
+	case got := <-errCh:
+		if !errors.Is(got, netx.ErrServerClosed) {
+			t.Fatalf("serve returned %v, want ErrServerClosed", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not exit after Close()")
+	}
+}
+
+func TestCloseClosesActiveConnections(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+	var s netx.Server[string]
+	s.Logger = logger
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(ctx, ln) }()
+
+	// Handler that matches and returns immediately, leaving the connection open
+	s.SetRoute("id", func(_ context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+		return true, conn
+	})
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	// Give the server a moment to register the connection
+	time.Sleep(100 * time.Millisecond)
+
+	// Closing the server should close the client connection too
+	if err := s.Close(); err != nil && !errors.Is(err, netx.ErrServerClosed) {
+		t.Fatalf("server close: %v", err)
+	}
+
+	_ = c.SetWriteDeadline(time.Now().Add(1 * time.Second))
+	if _, err := c.Write([]byte("ping")); err == nil {
+		// If write succeeded, a subsequent read should fail/EOF
+		_ = c.SetReadDeadline(time.Now().Add(1 * time.Second))
+		buf := make([]byte, 4)
+		if _, rErr := c.Read(buf); rErr == nil {
+			t.Fatalf("expected read error/EOF after server Close, got nil")
+		}
+	}
+	_ = c.Close()
+
+	select {
+	case got := <-errCh:
+		if !errors.Is(got, netx.ErrServerClosed) {
+			t.Fatalf("serve returned %v, want ErrServerClosed", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not exit after Close()")
+	}
+}
+
+func TestConcurrentSetRouteNoLoss(t *testing.T) {
+	t.Parallel()
+	var s netx.Server[int]
+	ctx := context.Background()
+	logger := &memLogger{}
+	s.Logger = logger
+
+	// Concurrently add many distinct routes
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			s.SetRoute(i, func(_ context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+				return false, conn
+			})
+		}()
+	}
+	wg.Wait()
+
+	// Inspect routes by adding a special route that we can observe by attempting connections
+	// Since routes are internal, we verify indirectly by racing a RemoveRoute for each id and
+	// ensure it doesn't panic and after removals, a connection is unhandled with no crash.
+	for i := 0; i < n; i++ {
+		s.RemoveRoute(i)
+	}
+
+	// Start the server with no routes and ensure it handles gracefully under connections
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(ctx, ln) }()
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_ = c.SetDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, _ = c.Read(buf) // should be dropped
+	_ = c.Close()
+
+	_ = s.Close()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not exit after Close()")
+	}
+}
+
+func TestShutdownGraceful(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+	var s netx.Server[string]
+	s.Logger = logger
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(ctx, ln) }()
+
+	// Handler that reads until client closes then signals closed()
+	s.SetRoute("id", func(_ context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+		go func() {
+			buf := make([]byte, 1024)
+			for {
+				if _, err := conn.Read(buf); err != nil {
+					break
+				}
+			}
+			closed()
+		}()
+		return true, conn
+	})
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	// Initiate graceful shutdown with sufficient timeout; while waiting, close client
+	sdCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Shutdown(sdCtx) }()
+
+	// Give server a moment, then close client to simulate graceful completion
+	time.Sleep(50 * time.Millisecond)
+	_ = c.Close()
+
+	if err := <-done; err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	select {
+	case got := <-errCh:
+		if !errors.Is(got, netx.ErrServerClosed) {
+			t.Fatalf("serve returned %v, want ErrServerClosed", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not exit after Shutdown()")
+	}
+}
+
+func TestShutdownTimeoutForcesClose(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+	var s netx.Server[string]
+	s.Logger = logger
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(ctx, ln) }()
+
+	// Handler reads an initial byte to ensure it blocks until client writes;
+	// after reading, it returns and the server will track the connection.
+	ready := make(chan struct{})
+	s.SetRoute("id", func(_ context.Context, conn net.Conn, closed func()) (bool, io.Closer) {
+		go func() {
+			// signal that handler is installed
+			close(ready)
+			buf := make([]byte, 1)
+			_, _ = io.ReadFull(conn, buf)
+			// do not call closed(); keep connection open for shutdown to force-close
+		}()
+		return true, conn
+	})
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	// Wait until handler goroutine is ready, then write the sync byte so handler returns and server tracks the conn
+	<-ready
+	if _, err := c.Write([]byte{0x1}); err != nil {
+		t.Fatalf("client sync write: %v", err)
+	}
+	// Small delay to let server add to tracked conns deterministically
+	time.Sleep(10 * time.Millisecond)
+
+	// Shutdown with short timeout; expect context deadline error
+	sdCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err = s.Shutdown(sdCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown error = %v, want DeadlineExceeded", err)
+	}
+	if time.Since(start) < 80*time.Millisecond { // guard against returning too early
+		t.Fatalf("Shutdown returned too quickly")
+	}
+
+	// Connection should be closed by server force-close
+	_ = c.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	buf := make([]byte, 1)
+	if _, rErr := c.Read(buf); rErr == nil {
+		t.Fatalf("expected read error after forced shutdown")
+	}
+	_ = c.Close()
+
+	// Serve should exit after Shutdown forced close
+	select {
+	case got := <-errCh:
+		if !errors.Is(got, netx.ErrServerClosed) {
+			t.Fatalf("serve returned %v, want ErrServerClosed", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not exit after forced Shutdown()")
+	}
+}

--- a/tun.go
+++ b/tun.go
@@ -1,0 +1,110 @@
+package netx
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync/atomic"
+)
+
+// Tun is an endpoint of a tunnel connection between two net.Conns.
+// Conn is the underlying connection of the tunnel and Peer is the client/server communicating with the tunnel.
+type Tun struct {
+	Logger     Logger
+	Conn       net.Conn
+	Peer       net.Conn
+	BufferSize uint // BufferSize for io.Copy, default 32KB
+	inShutdown atomic.Bool
+}
+
+// Relay copies data between the two connections until
+func (t *Tun) Relay(ctx context.Context) {
+	if t.Logger == nil {
+		t.Logger = slog.Default()
+	}
+
+	sendErrCh := make(chan error, 1)
+	recvErrCh := make(chan error, 1)
+
+	go t.halfCopy(t.Conn, t.Peer, sendErrCh)
+	go t.halfCopy(t.Peer, t.Conn, recvErrCh)
+
+	sendErr := <-sendErrCh
+	recvErr := <-recvErrCh
+	if sendErr != nil {
+		t.Logger.ErrorContext(ctx, "error copying data from tun to peer", "error", sendErr.Error())
+	}
+	if recvErr != nil {
+		t.Logger.ErrorContext(ctx, "error copying data from peer to tun", "error", recvErr.Error())
+	}
+}
+
+func (t *Tun) halfCopy(src io.ReadCloser, dst io.WriteCloser, errCh chan<- error) {
+	var buf []byte
+	if t.BufferSize != 0 {
+		buf = make([]byte, t.BufferSize)
+	}
+	defer t.Close()
+	_, err := io.CopyBuffer(dst, src, buf)
+	if t.shuttingDown() {
+		errCh <- nil
+		return
+	}
+	errCh <- err
+}
+
+func (t *Tun) Close() error {
+	t.inShutdown.Store(true)
+	connErr := t.Conn.Close()
+	if errors.Is(connErr, net.ErrClosed) {
+		connErr = nil
+	}
+	peerErr := t.Peer.Close()
+	if errors.Is(peerErr, net.ErrClosed) {
+		peerErr = nil
+	}
+	return errors.Join(connErr, peerErr)
+}
+
+func (t *Tun) shuttingDown() bool {
+	return t.inShutdown.Load()
+}
+
+type TunHandler func(ctx context.Context, conn net.Conn) (matched bool, connCtx context.Context, tunnel Tun)
+
+// TunMaster initially accepts no connections, since there are no known tunnel handlers.
+// It's the duty of the caller to add tunnel handlers via SetHandler.
+// The generic ID type is used to identify different tunnel handlers, e.g. by a client ID or username.
+type TunMaster[ID comparable] struct {
+	Server[ID]
+}
+
+// SetRoute sets a tunnel handler for a specific ID.
+// If a handler already exists for this ID, it will be replaced.
+// It does not close any existing tunnels that were created by the previous handler, but new tunnels will use the new handler.
+func (m *TunMaster[ID]) SetRoute(id ID, handler TunHandler) {
+	m.Server.SetRoute(id, func(connCtx context.Context, conn net.Conn, closed func()) (matched bool, tun io.Closer) {
+		matched, connCtx, tunnel := handler(connCtx, conn)
+		if !matched {
+			return false, conn
+		}
+
+		m.Logger.InfoContext(connCtx, "starting new tunnel",
+			"tun", tunnel.Conn.RemoteAddr().Network()+"://"+tunnel.Conn.RemoteAddr().String(),
+			"peer", tunnel.Peer.RemoteAddr().Network()+"://"+tunnel.Peer.RemoteAddr().String(),
+		)
+
+		go func() {
+			tunnel.Relay(connCtx)
+			closed()
+			m.Logger.InfoContext(connCtx, "tunnel closed",
+				"tun", tunnel.Conn.RemoteAddr().Network()+"://"+tunnel.Conn.RemoteAddr().String(),
+				"peer", tunnel.Peer.RemoteAddr().Network()+"://"+tunnel.Peer.RemoteAddr().String(),
+			)
+		}()
+
+		return true, &tunnel
+	})
+}

--- a/tun_e2e_udp_tcp_test.go
+++ b/tun_e2e_udp_tcp_test.go
@@ -1,0 +1,367 @@
+package netx_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	netx "github.com/pedramktb/go-netx"
+)
+
+// chanListener is an in-memory net.Listener that yields connections from a channel.
+type chanListener struct {
+	ch   chan net.Conn
+	done chan struct{}
+	addr net.Addr
+}
+
+func newChanListener() *chanListener {
+	return &chanListener{
+		ch:   make(chan net.Conn, 1),
+		done: make(chan struct{}),
+		addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+}
+
+func (l *chanListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.ch:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *chanListener) Close() error   { close(l.done); return nil }
+func (l *chanListener) Addr() net.Addr { return l.addr }
+
+// newUDPPair creates two UDP conns connected to each other on localhost.
+func newUDPPair(t *testing.T) (*net.UDPConn, *net.UDPConn) {
+	t.Helper()
+	// First, listen on two ephemeral ports to learn addresses
+	la, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP a: %v", err)
+	}
+	lb, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP b: %v", err)
+	}
+	aAddr := la.LocalAddr().(*net.UDPAddr)
+	bAddr := lb.LocalAddr().(*net.UDPAddr)
+	// Close listeners so we can bind same local ports for connected sockets
+	_ = la.Close()
+	_ = lb.Close()
+
+	// Create connected UDP endpoints using the discovered addresses
+	a, err := net.DialUDP("udp", aAddr, bAddr)
+	if err != nil {
+		t.Fatalf("DialUDP a->b: %v", err)
+	}
+	b, err := net.DialUDP("udp", bAddr, a.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		_ = a.Close()
+		t.Fatalf("DialUDP b->a: %v", err)
+	}
+	_ = a.SetDeadline(time.Now().Add(3 * time.Second))
+	_ = b.SetDeadline(time.Now().Add(3 * time.Second))
+	return a, b
+}
+
+func TestE2E_UDP_over_TCP_TunMasters(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+
+	// UDP peers: clientPeer <-> clientTunUDP, serverTunUDP <-> serverPeer
+	clientPeer, clientTunUDP := newUDPPair(t)
+	t.Cleanup(func() { _ = clientPeer.Close(); _ = clientTunUDP.Close() })
+	serverTunUDP, serverPeer := newUDPPair(t)
+	t.Cleanup(func() { _ = serverTunUDP.Close(); _ = serverPeer.Close() })
+
+	// Tunnel between TunMasters (use in-memory pipe)
+	tmClientSide, tmServerSide := net.Pipe()
+	t.Cleanup(func() { _ = tmClientSide.Close(); _ = tmServerSide.Close() })
+
+	// In-memory listeners to feed each TunMaster one connection endpoint
+	lClient := newChanListener()
+	lServer := newChanListener()
+
+	// Client TunMaster: bridge UDP<->framed stream (towards server)
+	var tmClient netx.TunMaster[string]
+	tmClient.Logger = logger
+	tmClient.SetRoute("route", func(connCtx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
+		// Wrap the stream side with framing to preserve UDP datagrams
+		fc := netx.NewFramedConn(conn)
+		return true, connCtx, netx.Tun{
+			Logger:     logger,
+			Conn:       fc,
+			Peer:       clientTunUDP,
+			BufferSize: 64 << 10, // 64KB to safely carry typical UDP datagrams in one read
+		}
+	})
+
+	// Server TunMaster: bridge framed stream<->UDP (towards server UDP peer)
+	var tmServer netx.TunMaster[string]
+	tmServer.Logger = logger
+	tmServer.SetRoute("route", func(connCtx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
+		fc := netx.NewFramedConn(conn)
+		return true, connCtx, netx.Tun{
+			Logger:     logger,
+			Conn:       fc,
+			Peer:       serverTunUDP,
+			BufferSize: 64 << 10,
+		}
+	})
+
+	// Start serving
+	errChClient := make(chan error, 1)
+	errChServer := make(chan error, 1)
+	go func() { errChClient <- tmClient.Serve(ctx, lClient) }()
+	go func() { errChServer <- tmServer.Serve(ctx, lServer) }()
+
+	// Deliver the pipe endpoints as the accepted connections
+	lClient.ch <- tmClientSide
+	lServer.ch <- tmServerSide
+
+	// Allow some time for tunnels to spin up
+	time.Sleep(50 * time.Millisecond)
+
+	// Datagrams from client -> server
+	_ = clientPeer.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	msg1 := []byte("hello from client via UDP")
+	if _, err := clientPeer.Write(msg1); err != nil {
+		t.Fatalf("clientPeer write: %v", err)
+	}
+	_ = serverPeer.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 2048)
+	n, err := serverPeer.Read(buf)
+	if err != nil {
+		t.Fatalf("serverPeer read: %v", err)
+	}
+	if string(buf[:n]) != string(msg1) {
+		t.Fatalf("serverPeer got %q want %q", string(buf[:n]), string(msg1))
+	}
+
+	// Datagrams from server -> client
+	_ = serverPeer.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	msg2 := []byte("hello from server via UDP")
+	if _, err := serverPeer.Write(msg2); err != nil {
+		t.Fatalf("serverPeer write: %v", err)
+	}
+	_ = clientPeer.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err = clientPeer.Read(buf)
+	if err != nil {
+		t.Fatalf("clientPeer read: %v", err)
+	}
+	if string(buf[:n]) != string(msg2) {
+		t.Fatalf("clientPeer got %q want %q", string(buf[:n]), string(msg2))
+	}
+
+	// Shutdown both masters gracefully
+	sdCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := tmClient.Shutdown(sdCtx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("tmClient Shutdown: %v", err)
+	}
+	if err := tmServer.Shutdown(sdCtx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("tmServer Shutdown: %v", err)
+	}
+}
+
+// Test routing on a single server listener with two routes:
+// - TLS route: expects a tls.Conn and forwards to server UDPTLS peer
+// - Plain route: handles non-TLS and forwards to server UDPPlain peer
+// Two client tunnels are created: one plain over framed stream, one framed over TLS.
+func TestE2E_TunMasterRouting_PlainAndTLS(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+
+	// Server UDP peers (targets after decapsulation)
+	serverTunUDPPlain, serverPeerPlain := newUDPPair(t)
+	t.Cleanup(func() { _ = serverTunUDPPlain.Close(); _ = serverPeerPlain.Close() })
+	serverTunUDPTLS, serverPeerTLS := newUDPPair(t)
+	t.Cleanup(func() { _ = serverTunUDPTLS.Close(); _ = serverPeerTLS.Close() })
+
+	// Server TunMaster with a single listener
+	lServer := newChanListener()
+	var tmServer netx.TunMaster[string]
+	tmServer.Logger = logger
+
+	// Route 1: TLS first
+	tmServer.SetRoute("tls", func(connCtx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
+		// Match if the connection looks like a tls.Conn
+		if _, ok := conn.(interface{ ConnectionState() tls.ConnectionState }); !ok {
+			return false, connCtx, netx.Tun{}
+		}
+		fc := netx.NewFramedConn(conn)
+		return true, connCtx, netx.Tun{Logger: logger, Conn: fc, Peer: serverTunUDPTLS, BufferSize: 64 << 10}
+	})
+
+	// Route 2: Plain fallback
+	tmServer.SetRoute("plain", func(connCtx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
+		// If it wasn't TLS, handle as plain framed
+		if _, ok := conn.(interface{ ConnectionState() tls.ConnectionState }); ok {
+			return false, connCtx, netx.Tun{}
+		}
+		fc := netx.NewFramedConn(conn)
+		return true, connCtx, netx.Tun{Logger: logger, Conn: fc, Peer: serverTunUDPPlain, BufferSize: 64 << 10}
+	})
+
+	// Start server
+	errChServer := make(chan error, 1)
+	go func() { errChServer <- tmServer.Serve(ctx, lServer) }()
+
+	// Create client tunnels for plain and TLS, and feed server with their counterparts.
+	// Plain connection pair
+	clientPlain, serverPlain := net.Pipe()
+	t.Cleanup(func() { _ = clientPlain.Close(); _ = serverPlain.Close() })
+
+	// TLS connection pair (wrap pipe ends)
+	cTLSRaw, sTLSRaw := net.Pipe()
+	t.Cleanup(func() { _ = cTLSRaw.Close(); _ = sTLSRaw.Close() })
+	srvCfg := &tls.Config{Certificates: []tls.Certificate{mustSelfSignedCert(t)}}
+	cliCfg := &tls.Config{InsecureSkipVerify: true}
+	tlsServer := tls.Server(sTLSRaw, srvCfg)
+	tlsClient := tls.Client(cTLSRaw, cliCfg)
+	t.Cleanup(func() { _ = tlsClient.Close(); _ = tlsServer.Close() })
+
+	// Client-side UDP peers (sources before encapsulation and sinks after decapsulation)
+	clientPeerPlain, clientTunUDPPlain := newUDPPair(t)
+	t.Cleanup(func() { _ = clientPeerPlain.Close(); _ = clientTunUDPPlain.Close() })
+	clientPeerTLS, clientTunUDPTLS := newUDPPair(t)
+	t.Cleanup(func() { _ = clientPeerTLS.Close(); _ = clientTunUDPTLS.Close() })
+
+	// Start client-side relays
+	go (&netx.Tun{Logger: logger, Conn: netx.NewFramedConn(clientPlain), Peer: clientTunUDPPlain, BufferSize: 64 << 10}).Relay(ctx)
+	go (&netx.Tun{Logger: logger, Conn: netx.NewFramedConn(tlsClient), Peer: clientTunUDPTLS, BufferSize: 64 << 10}).Relay(ctx)
+
+	// Deliver server-side connections to a single listener to test routing
+	lServer.ch <- serverPlain // should match plain route
+	lServer.ch <- tlsServer   // should match TLS route
+
+	// Give tunnels time to initialize and (for TLS) handshake on first IO
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify plain path client -> server
+	msgP := []byte("plain: hello")
+	_ = clientPeerPlain.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	if _, err := clientPeerPlain.Write(msgP); err != nil {
+		t.Fatalf("clientPeerPlain write: %v", err)
+	}
+	_ = serverPeerPlain.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 2048)
+	n, err := serverPeerPlain.Read(buf)
+	if err != nil {
+		t.Fatalf("serverPeerPlain read: %v", err)
+	}
+	if string(buf[:n]) != string(msgP) {
+		t.Fatalf("serverPeerPlain got %q want %q", string(buf[:n]), string(msgP))
+	}
+
+	// Verify TLS path client -> server
+	msgT := []byte("tls: hello")
+	_ = clientPeerTLS.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	if _, err := clientPeerTLS.Write(msgT); err != nil {
+		t.Fatalf("clientPeerTLS write: %v", err)
+	}
+	_ = serverPeerTLS.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err = serverPeerTLS.Read(buf)
+	if err != nil {
+		t.Fatalf("serverPeerTLS read: %v", err)
+	}
+	if string(buf[:n]) != string(msgT) {
+		t.Fatalf("serverPeerTLS got %q want %q", string(buf[:n]), string(msgT))
+	}
+
+	// Verify reverse direction for both routes
+	_ = serverPeerPlain.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	rspP := []byte("plain: world")
+	if _, err := serverPeerPlain.Write(rspP); err != nil {
+		t.Fatalf("serverPeerPlain write: %v", err)
+	}
+	_ = clientPeerPlain.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err = clientPeerPlain.Read(buf)
+	if err != nil {
+		t.Fatalf("clientPeerPlain read: %v", err)
+	}
+	if string(buf[:n]) != string(rspP) {
+		t.Fatalf("clientPeerPlain got %q want %q", string(buf[:n]), string(rspP))
+	}
+
+	_ = serverPeerTLS.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	rspT := []byte("tls: world")
+	if _, err := serverPeerTLS.Write(rspT); err != nil {
+		t.Fatalf("serverPeerTLS write: %v", err)
+	}
+	_ = clientPeerTLS.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err = clientPeerTLS.Read(buf)
+	if err != nil {
+		t.Fatalf("clientPeerTLS read: %v", err)
+	}
+	if string(buf[:n]) != string(rspT) {
+		t.Fatalf("clientPeerTLS got %q want %q", string(buf[:n]), string(rspT))
+	}
+
+	// Cleanup: close client stream sides to end tunnels and allow graceful shutdown
+	_ = clientPlain.Close()
+	_ = tlsClient.Close()
+
+	// Graceful shutdown of server
+	sdCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := tmServer.Shutdown(sdCtx); err != nil {
+		t.Fatalf("tmServer Shutdown: %v", err)
+	}
+	select {
+	case got := <-errChServer:
+		if got != nil && !errors.Is(got, netx.ErrServerClosed) {
+			t.Fatalf("Serve returned %v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("server did not exit after Shutdown")
+	}
+}
+
+// mustSelfSignedCert returns a TLS certificate for tests.
+func mustSelfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	// Generate an ECDSA self-signed certificate for localhost testing
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(10 * time.Minute),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("x509 key pair: %v", err)
+	}
+	return cert
+}

--- a/tun_test.go
+++ b/tun_test.go
@@ -1,0 +1,174 @@
+package netx_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pedramktb/go-netx"
+)
+
+func TestTunRelayBidirectional(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+	var m netx.TunMaster[string]
+	m.Logger = logger
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.Serve(ctx, ln) }()
+
+	peerCh := make(chan net.Conn, 1)
+	m.SetRoute("id", func(connCtx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
+		a, b := net.Pipe() // a is server-side peer, b is test-side peer
+		peerCh <- b
+		return true, connCtx, netx.Tun{Logger: logger, Conn: conn, Peer: a}
+	})
+
+	// Connect client
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	_ = c.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Get the peer end created by handler
+	peer := <-peerCh
+	t.Cleanup(func() { _ = peer.Close() })
+	_ = peer.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// client -> peer
+	msg1 := []byte("hello from client")
+	if _, err := c.Write(msg1); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, len(msg1))
+	if _, err := io.ReadFull(peer, buf); err != nil {
+		t.Fatalf("peer read: %v", err)
+	}
+	if string(buf) != string(msg1) {
+		t.Fatalf("mismatch: got %q want %q", string(buf), string(msg1))
+	}
+
+	// peer -> client
+	msg2 := []byte("hello from peer")
+	if _, err := peer.Write(msg2); err != nil {
+		t.Fatalf("peer write: %v", err)
+	}
+	buf2 := make([]byte, len(msg2))
+	if _, err := io.ReadFull(c, buf2); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(buf2) != string(msg2) {
+		t.Fatalf("mismatch: got %q want %q", string(buf2), string(msg2))
+	}
+
+	// Close ends to let tunnel finish
+	_ = c.Close()
+	_ = peer.Close()
+
+	// Graceful shutdown should complete quickly
+	sdCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := m.Shutdown(sdCtx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case got := <-errCh:
+		if !errors.Is(got, netx.ErrServerClosed) {
+			t.Fatalf("serve returned %v, want ErrServerClosed", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not exit after Shutdown()")
+	}
+}
+
+func TestTunShutdownTimeoutForcesClose(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := &memLogger{}
+	var m netx.TunMaster[string]
+	m.Logger = logger
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.Serve(ctx, ln) }()
+
+	peerCh := make(chan net.Conn, 1)
+	ready := make(chan struct{})
+	m.SetRoute("id", func(connCtx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
+		a, b := net.Pipe()
+		close(ready)
+		peerCh <- b
+		return true, connCtx, netx.Tun{Logger: logger, Conn: conn, Peer: a}
+	})
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_ = c.SetDeadline(time.Now().Add(2 * time.Second))
+	peer := <-peerCh
+	_ = peer.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Ensure the tunnel is set up and tracked before shutdown
+	<-ready
+	// Prove relay is active by sending a byte through the tunnel
+	if _, err := c.Write([]byte("x")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	_ = peer.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	b := make([]byte, 1)
+	if _, err := io.ReadFull(peer, b); err != nil {
+		t.Fatalf("peer read: %v", err)
+	}
+	// Do not close endpoints; trigger forced shutdown
+	sdCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if err := m.Shutdown(sdCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown error = %v, want DeadlineExceeded", err)
+	}
+
+	// After forced shutdown, reads/writes should error
+	if _, err := c.Write([]byte("x")); err == nil {
+		// expect error
+		_ = c.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		b := make([]byte, 1)
+		if _, rErr := c.Read(b); rErr == nil {
+			t.Fatalf("expected client read error after forced shutdown")
+		}
+	}
+	if _, err := peer.Write([]byte("y")); err == nil {
+		_ = peer.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		b := make([]byte, 1)
+		if _, rErr := peer.Read(b); rErr == nil {
+			t.Fatalf("expected peer read error after forced shutdown")
+		}
+	}
+	_ = c.Close()
+	_ = peer.Close()
+
+	select {
+	case got := <-errCh:
+		if !errors.Is(got, netx.ErrServerClosed) {
+			t.Fatalf("serve returned %v, want ErrServerClosed", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not exit after Shutdown()")
+	}
+}


### PR DESCRIPTION
- Add BufConn: buffered net.Conn with Flush and configurable sizes
- Add FramedConn: 4-byte BE length-prefixed frames, max size, empty-frame support
- Add Server[ID]: runtime route add/replace/remove, copy-on-write, Close/Shutdown
- Add Tun and TunMaster[ID]: bidirectional relay; bridge UDP over framed TCP
- Add simple Logger interface; default to slog when nil
- Add unit/E2E tests (buffered, framed, routing, graceful shutdown, UDP/TCP, TLS)
- Add README, LICENSE, go.mod, Taskfile, CHANGELOG