### PR TITLE
fix(transport): enlarge UDP socket buffers to absorb peer bursts

### DIFF
--- a/cli/internal/tun.go
+++ b/cli/internal/tun.go
@@ -80,7 +80,10 @@ func runTun(ctx context.Context, cancel context.CancelFunc, from, to string) err
 			return false, ctx, netx.Tun{}
 		}
 
-		return true, ctx, netx.Tun{Conn: conn, Peer: pconn}
+		// 64KB copy buffer (matches the integration tests) so a single read can
+		// carry a full datagram with headroom; default-0 would fall back to Go's
+		// 32KB io.Copy buffer.
+		return true, ctx, netx.Tun{Conn: conn, Peer: pconn, BufferSize: 64 << 10}
 	})
 
 	go func() {

--- a/dial.go
+++ b/dial.go
@@ -7,6 +7,16 @@ import (
 	pudp "github.com/pion/transport/v3/udp"
 )
 
+// defaultUDPSocketBuffer is the OS receive/send buffer applied to UDP sockets (the
+// loopback listener and the upstream dialer) unless the caller overrides it.
+// Without it the platform default applies, and Windows' (~64 KB) is small enough
+// that a burst — a download flight from the server, or a userspace WireGuard
+// adapter flushing across loopback — overflows the socket faster than the relay
+// goroutine drains it. The dropped datagrams force inner-TCP retransmits and
+// collapse throughput; a few MiB of headroom absorbs the bursts. Linux's far
+// larger default rmem masks this, which is why the regression was Windows-only.
+const defaultUDPSocketBuffer = 4 << 20 // 4 MiB
+
 type listenCfg struct {
 	net.ListenConfig
 	packet pudp.ListenConfig
@@ -36,6 +46,16 @@ func Listen(ctx context.Context, network, addr string, opts ...ListenOption) (ne
 		uaddr, err := net.ResolveUDPAddr(network, addr)
 		if err != nil {
 			return nil, err
+		}
+		// Default the OS socket buffers so a bursty peer can't overflow them
+		// (see defaultUDPSocketBuffer). Only fills unset values — an explicit
+		// WithPacketListenConfig still wins. pion applies these via
+		// SetReadBuffer/SetWriteBuffer on the underlying conn.
+		if cfg.packet.ReadBufferSize == 0 {
+			cfg.packet.ReadBufferSize = defaultUDPSocketBuffer
+		}
+		if cfg.packet.WriteBufferSize == 0 {
+			cfg.packet.WriteBufferSize = defaultUDPSocketBuffer
 		}
 		return cfg.packet.Listen(network, uaddr)
 	case "icmp":
@@ -100,6 +120,19 @@ func Dial(ctx context.Context, network, addr string, opts ...DialOption) (net.Co
 		}
 		return NewICMPClientConn(conn, version)
 	default:
-		return cfg.DialContext(ctx, network, addr)
+		conn, err := cfg.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		// Enlarge the OS socket buffers on UDP so a fast download burst from the
+		// server is absorbed by the kernel instead of overflowing the small
+		// platform default while the relay goroutine is momentarily descheduled
+		// (see defaultUDPSocketBuffer). TCP autotunes its own window, so this is
+		// scoped to *net.UDPConn.
+		if uc, ok := conn.(*net.UDPConn); ok {
+			_ = uc.SetReadBuffer(defaultUDPSocketBuffer)
+			_ = uc.SetWriteBuffer(defaultUDPSocketBuffer)
+		}
+		return conn, nil
 	}
 }


### PR DESCRIPTION
## Problem
netx creates its UDP sockets — the loopback listener in `Listen` and the upstream
dialer in `Dial` — with the OS default socket buffer.

That's fine on Linux (large default rmem/wmem), but **Windows' default UDP socket
buffer is ~64 KB**, too small to absorb a burst. In a `tun` relay between a userspace
WireGuard adapter (loopback) and a fast server, a download flight arrives as a
microburst of datagrams; if the relay goroutine is briefly descheduled the ~64 KB
socket overflows and **silently drops datagrams**. The inner TCP flow retransmits and
backs off, collapsing throughput.

In the field (Ironlink, a WireGuard-over-netx client) this was a catastrophic,
Windows-only regression: single-flow `udp+dtls` **download collapsed to ~0.14 Mbps**,
while macOS/Linux on the same network and server were unaffected.

## Fix
Default the OS receive/send buffer on UDP sockets to **4 MiB**, both directions:
- `Listen` (`udp` case): fill `cfg.packet.ReadBufferSize`/`WriteBufferSize` when unset
  (pion applies them via `SetReadBuffer`/`SetWriteBuffer`); an explicit
  `WithPacketListenConfig` still wins.
- `Dial` (default case): `SetReadBuffer`/`SetWriteBuffer` on the `*net.UDPConn`. TCP is
  left alone (it autotunes its own window).
- `cli/internal/tun.go`: 64 KB relay copy buffer so a single read carries a full
  datagram with headroom (matches the integration tests).

The 4 MiB default is conservative and overridable; where the OS default already exceeds
the burst working set (Linux) it's effectively a no-op.

## Impact
- **Windows `udp+dtls` download: ~0.14 → ~44 Mbps**; connect latency 527 → ~78 ms;
  upload already at parity. Verified end-to-end against a live server.
- **No wire-format or API change** — `Listen`/`Dial` signatures unchanged, sizes remain
  overridable.
- No measurable change on Linux/macOS (their defaults already cover the bursts).

## Files
- `dial.go` — UDP buffer defaults in `Listen` + `Dial`
- `cli/internal/tun.go` — 64 KB relay copy buffer