### PR TITLE
feat(dtls,dtlspsk): tunable handshake params + session resumption

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,9 +159,13 @@ tasks:
         # Use isolated ports to avoid conflicts with external demos
         TE=48080; UE=48081
         STLS=49000; SDTLS=49100; SDTLSP=49300; SAESCT=49400; SAESCU=49500; SFR=49600; STLSPSK=49200; SSSH=49700; SUTLS=49800; SREALITY=49900
+        # Tuned DTLS variants (mtu/flightinterval/skipcookie/resume) — the new fast obfuscation params.
+        SDTLST=49110; SDTLSPT=49310
         # DNST Ports: SDNST_AUTH is the Authoritative Server (netx). SDNST_RES is the Mock Public Resolver.
         SDNST_AUTH=49950; SDNST_RES=49951
         CTLS=50000; CDTLS=50010; CDTLSP=50011; CAESCT=50002; CAESCU=50012; CFR=50003; CTLSPSK=50001; CSSH=50004; CUTLS=50005; CDNST=50050; CREALITY=50006
+        # Tuned DTLS clients.
+        CDTLST=50013; CDTLSPT=50014
 
         echo "Starting echo servers..."
         ./tcp_echo 127.0.0.1:${TE} > tcp_echo.log 2>&1 &
@@ -174,6 +178,8 @@ tasks:
         "$NETX" tun --from "tcp+tls{cert=$(xxd -p server.crt | tr -d '\n'),key=$(xxd -p server.key | tr -d '\n')}://127.0.0.1:${STLS}"                --to "tcp://127.0.0.1:${TE}"  --log info > tls_server.log         2>&1 &
         "$NETX" tun --from "udp+dtls{cert=$(xxd -p server.crt | tr -d '\n'),key=$(xxd -p server.key | tr -d '\n')}://127.0.0.1:${SDTLS}"              --to "udp://127.0.0.1:${UE}"  --log info > dtls_server.log        2>&1 &
         "$NETX" tun --from "udp+dtlspsk{identity=i,key=$(cat psk.hex)}://127.0.0.1:${SDTLSP}"                                                         --to "udp://127.0.0.1:${UE}"  --log info > dtlspsk_server.log     2>&1 &
+        "$NETX" tun --from "udp+dtls{cert=$(xxd -p server.crt | tr -d '\n'),key=$(xxd -p server.key | tr -d '\n'),mtu=1200,flightinterval=300ms,skipcookie=true}://127.0.0.1:${SDTLST}"                 --to "udp://127.0.0.1:${UE}"  --log info > dtls_tuned_server.log    2>&1 &
+        "$NETX" tun --from "udp+dtlspsk{identity=i,key=$(cat psk.hex),mtu=1200,flightinterval=300ms,skipcookie=true,resume=true}://127.0.0.1:${SDTLSPT}"                                              --to "udp://127.0.0.1:${UE}"  --log info > dtlspsk_tuned_server.log 2>&1 &
         "$NETX" tun --from "tcp+buf{r=8192,w=8192}+frame+aesgcm{key=$(cat aes.hex)}://127.0.0.1:${SAESCT}"                                              --to "tcp://127.0.0.1:${TE}"  --log info > aesgcm_tcp_server.log  2>&1 &
         "$NETX" tun --from "udp+aesgcm{key=$(cat aes.hex)}://127.0.0.1:${SAESCU}"                                                                     --to "udp://127.0.0.1:${UE}"  --log info > aesgcm_udp_server.log  2>&1 &
         "$NETX" tun --from "tcp+frame://127.0.0.1:${SFR}"                                                                                             --to "udp://127.0.0.1:${UE}"  --log info > frame_tcp_server.log   2>&1 &
@@ -187,6 +193,8 @@ tasks:
         "$NETX" tun --from "tcp://127.0.0.1:${CTLS}"    --to "tcp+tls{cert=$(xxd -p server.crt | tr -d '\n')}://127.0.0.1:${STLS}"                                                      --log info > tls_client.log         2>&1 &
         "$NETX" tun --from "udp://127.0.0.1:${CDTLS}"   --to "udp+dtls{cert=$(xxd -p server.crt | tr -d '\n')}://127.0.0.1:${SDTLS}"                                                    --log info > dtls_client.log        2>&1 &
         "$NETX" tun --from "udp://127.0.0.1:${CDTLSP}"  --to "udp+dtlspsk{identity=i,key=$(cat psk.hex)}://127.0.0.1:${SDTLSP}"                                                         --log info > dtlspsk_client.log     2>&1 &
+        "$NETX" tun --from "udp://127.0.0.1:${CDTLST}"  --to "udp+dtls{cert=$(xxd -p server.crt | tr -d '\n'),mtu=1200,flightinterval=300ms}://127.0.0.1:${SDTLST}"                                        --log info > dtls_tuned_client.log    2>&1 &
+        "$NETX" tun --from "udp://127.0.0.1:${CDTLSPT}" --to "udp+dtlspsk{identity=i,key=$(cat psk.hex),mtu=1200,flightinterval=300ms,resume=true}://127.0.0.1:${SDTLSPT}"                                 --log info > dtlspsk_tuned_client.log 2>&1 &
         "$NETX" tun --from "tcp://127.0.0.1:${CAESCT}"  --to "tcp+buf{r=8192,w=8192}+frame+aesgcm{key=$(cat aes.hex)}://127.0.0.1:${SAESCT}"                                              --log info > aesgcm_tcp_client.log  2>&1 &
         "$NETX" tun --from "udp://127.0.0.1:${CAESCU}"  --to "udp+aesgcm{key=$(cat aes.hex)}://127.0.0.1:${SAESCU}"                                                                     --log info > aesgcm_udp_client.log  2>&1 &
         "$NETX" tun --from "udp://127.0.0.1:${CFR}"     --to "tcp+frame://127.0.0.1:${SFR}"                                                                                             --log info > frame_tcp_client.log   2>&1 &
@@ -206,6 +214,8 @@ tasks:
         run_tcp TLS           127.0.0.1:${CTLS}     hello_tls
         run_udp DTLS          127.0.0.1:${CDTLS}    hello_dtls
         run_udp DTLSPSK       127.0.0.1:${CDTLSP}   hello_dtlspsk
+        run_udp DTLS_TUNED    127.0.0.1:${CDTLST}   hello_dtls_tuned
+        run_udp DTLSPSK_TUNED 127.0.0.1:${CDTLSPT}  hello_dtlspsk_tuned
         run_tcp AESGCM_TCP    127.0.0.1:${CAESCT}   hello_aesgcm_tcp
         run_udp AESGCM_UDP    127.0.0.1:${CAESCU}   hello_aesgcm_udp
         run_udp FRAMED_TCP_BR 127.0.0.1:${CFR}      hello_udp_over_tcp

--- a/drivers/dtls/dtls.go
+++ b/drivers/dtls/dtls.go
@@ -9,6 +9,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net"
+	"strconv"
+	"time"
 
 	"github.com/pedramktb/go-netx"
 	"github.com/pion/dtls/v3"
@@ -35,6 +37,61 @@ func init() {
 				}
 			case "servername":
 				cfg.ServerName = value
+			case "mtu":
+				// Fragment handshake flights to fit the path MTU so DTLS records
+				// never IP-fragment (fragmented records are disproportionately
+				// dropped by middleboxes on censored paths). pion default 1200.
+				n, err := strconv.ParseUint(value, 10, 32)
+				if err != nil || n < 576 || n > 1500 {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtls mtu parameter %q (want 576..1500)", value)
+				}
+				cfg.MTU = int(n)
+			case "flightinterval":
+				// Initial handshake-retransmit interval (pion default 1s). A value
+				// a bit above the path RTT recovers a lost flight far faster on a
+				// lossy link. Must be positive.
+				d, err := time.ParseDuration(value)
+				if err != nil || d <= 0 {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtls flightinterval parameter %q: %w", value, err)
+				}
+				cfg.FlightInterval = d
+			case "nobackoff":
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtls nobackoff parameter %q: %w", value, err)
+				}
+				cfg.DisableRetransmitBackoff = b
+			case "skipcookie":
+				// Server-only: skip the HelloVerifyRequest cookie exchange,
+				// removing one round-trip from every fresh handshake. The cookie
+				// is anti-spoofing DoS protection; for an SPKI-pinned endpoint the
+				// handshake cannot complete without the pinned key, so abuse is
+				// bounded — rate-limit upstream if needed.
+				if !listener {
+					return netx.Wrapper{}, fmt.Errorf("uri: dtls skipcookie parameter is only valid for servers")
+				}
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtls skipcookie parameter %q: %w", value, err)
+				}
+				cfg.InsecureSkipVerifyHello = b
+			case "resume":
+				// Enable abbreviated-handshake session resumption (skips the
+				// Certificate flight for a returning peer). Backed by a bounded
+				// process-global store shared across listener/dialer instances.
+				//
+				// CAVEAT: with the certificate-based dtls driver, pion/dtls v3.1.2
+				// fails the *full* handshake when SessionStore is set on both ends
+				// with separate stores (the production client/server split). Prefer
+				// resumption on the dtlspsk driver, where it works. The param is
+				// still accepted here for completeness/forward-compat.
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtls resume parameter %q: %w", value, err)
+				}
+				if b {
+					cfg.SessionStore = sharedSessionStore()
+				}
 			default:
 				return netx.Wrapper{}, fmt.Errorf("uri: unknown dtls parameter %q", key)
 			}

--- a/drivers/dtls/dtls_test.go
+++ b/drivers/dtls/dtls_test.go
@@ -1,0 +1,192 @@
+package dtls
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	netx "github.com/pedramktb/go-netx"
+	"github.com/pion/dtls/v3"
+)
+
+// genECCertPEM produces an ECDSA P-256 self-signed leaf as PEM cert + SEC1 key —
+// the exact shape the Flutter client emits (EC PRIVATE KEY block) and that the
+// server's tls.X509KeyPair must accept.
+func genECCertPEM(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+func TestDTLSParamParsing(t *testing.T) {
+	cert, key := genECCertPEM(t)
+	c := hex.EncodeToString(cert)
+	k := hex.EncodeToString(key)
+
+	tests := []struct {
+		name    string
+		uri     string
+		server  bool
+		wantErr bool
+	}{
+		{"server valid tuned", fmt.Sprintf("udp+dtls{cert=%s,key=%s,mtu=1200,flightinterval=300ms,nobackoff=true,skipcookie=true,resume=true}://127.0.0.1:0", c, k), true, false},
+		{"client valid tuned", fmt.Sprintf("udp+dtls{cert=%s,mtu=1200,flightinterval=300ms,resume=true}://127.0.0.1:9000", c), false, false},
+		{"client skipcookie rejected", fmt.Sprintf("udp+dtls{cert=%s,skipcookie=true}://127.0.0.1:9000", c), false, true},
+		{"bad mtu low", fmt.Sprintf("udp+dtls{cert=%s,key=%s,mtu=10}://127.0.0.1:0", c, k), true, true},
+		{"bad mtu high", fmt.Sprintf("udp+dtls{cert=%s,key=%s,mtu=9999}://127.0.0.1:0", c, k), true, true},
+		{"bad flightinterval", fmt.Sprintf("udp+dtls{cert=%s,key=%s,flightinterval=nope}://127.0.0.1:0", c, k), true, true},
+		{"unknown param", fmt.Sprintf("udp+dtls{cert=%s,key=%s,bogus=1}://127.0.0.1:0", c, k), true, true},
+		{"legacy untuned still parses", fmt.Sprintf("udp+dtls{cert=%s,key=%s}://127.0.0.1:0", c, k), true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			if tt.server {
+				var u netx.ListenerURI
+				err = u.UnmarshalText([]byte(tt.uri))
+			} else {
+				var u netx.DialerURI
+				err = u.UnmarshalText([]byte(tt.uri))
+			}
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestDTLSHandshakeTuned proves a real DTLS tunnel with the new tuning params
+// (and an ECDSA cert) completes and echoes — i.e. the params are wired without
+// breaking the handshake.
+func TestDTLSHandshakeTuned(t *testing.T) {
+	cert, key := genECCertPEM(t)
+	c := hex.EncodeToString(cert)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// NOTE: cert-DTLS deliberately does NOT enable `resume` here. pion v3.1.2 has
+	// a quirk where a full certificate handshake with SessionStore set on both
+	// ends (separate stores, as in production's separate client/server processes)
+	// fails to complete; resumption is therefore shipped on the PSK path only
+	// (see dtlspsk_test.go), which is our fast scheme. mtu/flightinterval/
+	// skipcookie are the cert-path tunables and work fine.
+	var lu netx.ListenerURI
+	if err := lu.UnmarshalText([]byte(fmt.Sprintf(
+		"udp+dtls{cert=%s,key=%s,mtu=1200,flightinterval=200ms,skipcookie=true}://127.0.0.1:0",
+		c, hex.EncodeToString(key)))); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := lu.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go echoLoop(ln)
+
+	var du netx.DialerURI
+	if err := du.UnmarshalText([]byte(fmt.Sprintf(
+		"udp+dtls{cert=%s,mtu=1200,flightinterval=200ms}://%s", c, ln.Addr().String()))); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		conn, err := du.Dial(ctx)
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		if _, err := conn.Write([]byte("ping")); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+		buf := make([]byte, 64)
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if string(buf[:n]) != "ping" {
+			t.Fatalf("echo %d mismatch: %q", i, buf[:n])
+		}
+		_ = conn.Close()
+	}
+}
+
+func echoLoop(ln net.Listener) {
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		go func(c net.Conn) {
+			defer c.Close()
+			buf := make([]byte, 1500)
+			for {
+				n, err := c.Read(buf)
+				if err != nil {
+					return
+				}
+				if _, err := c.Write(buf[:n]); err != nil {
+					return
+				}
+			}
+		}(c)
+	}
+}
+
+func TestMemSessionStore(t *testing.T) {
+	s := &memSessionStore{m: make(map[string]dtls.Session), max: 2}
+
+	s.Set([]byte("a"), dtls.Session{ID: []byte{1}, Secret: []byte{2}})
+	got, _ := s.Get([]byte("a"))
+	if len(got.ID) != 1 || got.ID[0] != 1 || len(got.Secret) != 1 || got.Secret[0] != 2 {
+		t.Fatalf("get mismatch: %+v", got)
+	}
+
+	miss, _ := s.Get([]byte("missing"))
+	if miss.ID != nil {
+		t.Fatalf("expected zero session for missing key, got %+v", miss)
+	}
+
+	// Exceeding capacity evicts rather than growing unbounded.
+	s.Set([]byte("b"), dtls.Session{ID: []byte{3}})
+	s.Set([]byte("c"), dtls.Session{ID: []byte{4}})
+	if len(s.m) > 2 {
+		t.Fatalf("store exceeded max: %d", len(s.m))
+	}
+
+	s.Del([]byte("c"))
+	if _, ok := s.m["c"]; ok {
+		t.Fatalf("expected c deleted")
+	}
+}

--- a/drivers/dtls/session.go
+++ b/drivers/dtls/session.go
@@ -1,0 +1,75 @@
+package dtls
+
+import (
+	"sync"
+
+	"github.com/pion/dtls/v3"
+)
+
+// memSessionStore is a bounded, process-global in-memory dtls.SessionStore used
+// for abbreviated-handshake resumption (a returning peer skips the Certificate
+// flight). It is shared across every dtls listener/dialer in the process so a
+// resumable session survives the per-connect listener teardown on the server
+// side (the relay rebuilds its listener on each switch, but the store outlives
+// it). Entries are capped to bound memory; a peer whose session was evicted
+// simply performs a full handshake.
+type memSessionStore struct {
+	mu  sync.Mutex
+	m   map[string]dtls.Session
+	max int
+}
+
+func (s *memSessionStore) Set(key []byte, v dtls.Session) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.m[string(key)]; !exists && len(s.m) >= s.max {
+		// Bound memory: evict an arbitrary entry. Go randomizes map iteration
+		// order, so this approximates random eviction (a DoS-safe backstop, not
+		// an LRU — losing a ticket only forces a full handshake).
+		for k := range s.m {
+			delete(s.m, k)
+			break
+		}
+	}
+	s.m[string(key)] = dtls.Session{
+		ID:     append([]byte(nil), v.ID...),
+		Secret: append([]byte(nil), v.Secret...),
+	}
+	return nil
+}
+
+func (s *memSessionStore) Get(key []byte) (dtls.Session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[string(key)]
+	if !ok {
+		// A zero Session (ID == nil) signals "no session" — pion's flight
+		// handlers treat it as "no resumption" rather than an error.
+		return dtls.Session{}, nil
+	}
+	return dtls.Session{
+		ID:     append([]byte(nil), v.ID...),
+		Secret: append([]byte(nil), v.Secret...),
+	}, nil
+}
+
+func (s *memSessionStore) Del(key []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, string(key))
+	return nil
+}
+
+var (
+	sessionStoreOnce sync.Once
+	sessionStore     *memSessionStore
+)
+
+// sharedSessionStore returns the lazily-created, process-global resumption store
+// used by every dtls wrapper that opts in with the `resume` param.
+func sharedSessionStore() dtls.SessionStore {
+	sessionStoreOnce.Do(func() {
+		sessionStore = &memSessionStore{m: make(map[string]dtls.Session), max: 4096}
+	})
+	return sessionStore
+}

--- a/drivers/dtlspsk/dtlspsk.go
+++ b/drivers/dtlspsk/dtlspsk.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"strconv"
+	"time"
 
 	"github.com/pedramktb/go-netx"
 	"github.com/pion/dtls/v3"
@@ -14,6 +16,13 @@ func init() {
 	netx.Register("dtlspsk", func(params map[string]string, listener bool) (netx.Wrapper, error) {
 		var identity string
 		var psk []byte
+		var (
+			mtu            int
+			flightInterval time.Duration
+			noBackoff      bool
+			skipCookie     bool
+			resume         bool
+		)
 		for key, value := range params {
 			switch key {
 			case "key":
@@ -24,6 +33,47 @@ func init() {
 				}
 			case "identity":
 				identity = value
+			case "mtu":
+				// Fragment handshake flights to fit the path MTU so DTLS records
+				// never IP-fragment on censored paths. pion default 1200.
+				n, err := strconv.ParseUint(value, 10, 32)
+				if err != nil || n < 576 || n > 1500 {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtlspsk mtu parameter %q (want 576..1500)", value)
+				}
+				mtu = int(n)
+			case "flightinterval":
+				// Initial handshake-retransmit interval (pion default 1s); set a
+				// bit above the path RTT to recover lost flights faster on loss.
+				d, err := time.ParseDuration(value)
+				if err != nil || d <= 0 {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtlspsk flightinterval parameter %q: %w", value, err)
+				}
+				flightInterval = d
+			case "nobackoff":
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtlspsk nobackoff parameter %q: %w", value, err)
+				}
+				noBackoff = b
+			case "skipcookie":
+				// Server-only: skip the HelloVerifyRequest cookie round-trip. The
+				// PSK already gates abuse (a handshake can't complete without the
+				// shared key), so the dropped anti-spoof cookie is bounded.
+				if !listener {
+					return netx.Wrapper{}, fmt.Errorf("uri: dtlspsk skipcookie parameter is only valid for servers")
+				}
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtlspsk skipcookie parameter %q: %w", value, err)
+				}
+				skipCookie = b
+			case "resume":
+				// Abbreviated-handshake resumption (process-global bounded store).
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return netx.Wrapper{}, fmt.Errorf("uri: invalid dtlspsk resume parameter %q: %w", value, err)
+				}
+				resume = b
 			default:
 				return netx.Wrapper{}, fmt.Errorf("uri: unknown dtlspsk parameter %q", key)
 			}
@@ -41,6 +91,17 @@ func init() {
 			PSKIdentityHint:    []byte(identity),
 			CipherSuites:       []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_GCM_SHA256},
 			InsecureSkipVerify: true,
+		}
+		if mtu != 0 {
+			cfg.MTU = mtu
+		}
+		if flightInterval != 0 {
+			cfg.FlightInterval = flightInterval
+		}
+		cfg.DisableRetransmitBackoff = noBackoff
+		cfg.InsecureSkipVerifyHello = skipCookie
+		if resume {
+			cfg.SessionStore = sharedSessionStore()
 		}
 		if listener {
 			return netx.Wrapper{

--- a/drivers/dtlspsk/dtlspsk_test.go
+++ b/drivers/dtlspsk/dtlspsk_test.go
@@ -1,0 +1,135 @@
+package dtlspsk
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	netx "github.com/pedramktb/go-netx"
+	"github.com/pion/dtls/v3"
+)
+
+const testPSK = "00112233445566778899aabbccddeeff"
+
+func TestDTLSPSKParamParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		server  bool
+		wantErr bool
+	}{
+		{"server valid tuned", fmt.Sprintf("udp+dtlspsk{key=%s,identity=srv,mtu=1200,flightinterval=300ms,nobackoff=true,skipcookie=true,resume=true}://127.0.0.1:0", testPSK), true, false},
+		{"client valid tuned", fmt.Sprintf("udp+dtlspsk{key=%s,identity=cli,mtu=1200,flightinterval=300ms,resume=true}://127.0.0.1:9000", testPSK), false, false},
+		{"client requires identity", fmt.Sprintf("udp+dtlspsk{key=%s}://127.0.0.1:9000", testPSK), false, true},
+		{"client skipcookie rejected", fmt.Sprintf("udp+dtlspsk{key=%s,identity=cli,skipcookie=true}://127.0.0.1:9000", testPSK), false, true},
+		{"missing key", "udp+dtlspsk{identity=cli}://127.0.0.1:0", true, true},
+		{"bad mtu", fmt.Sprintf("udp+dtlspsk{key=%s,identity=srv,mtu=5}://127.0.0.1:0", testPSK), true, true},
+		{"unknown param", fmt.Sprintf("udp+dtlspsk{key=%s,identity=srv,bogus=1}://127.0.0.1:0", testPSK), true, true},
+		{"legacy untuned still parses", fmt.Sprintf("udp+dtlspsk{key=%s,identity=cli}://127.0.0.1:9000", testPSK), false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			if tt.server {
+				var u netx.ListenerURI
+				err = u.UnmarshalText([]byte(tt.uri))
+			} else {
+				var u netx.DialerURI
+				err = u.UnmarshalText([]byte(tt.uri))
+			}
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestDTLSPSKHandshakeTuned proves a real PSK DTLS tunnel with skipcookie +
+// resume + tuned timers completes and echoes (no cert flight).
+func TestDTLSPSKHandshakeTuned(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var lu netx.ListenerURI
+	if err := lu.UnmarshalText([]byte(fmt.Sprintf(
+		"udp+dtlspsk{key=%s,identity=srv,mtu=1200,flightinterval=200ms,skipcookie=true,resume=true}://127.0.0.1:0",
+		testPSK))); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := lu.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1500)
+				for {
+					n, err := c.Read(buf)
+					if err != nil {
+						return
+					}
+					if _, err := c.Write(buf[:n]); err != nil {
+						return
+					}
+				}
+			}(c)
+		}
+	}()
+
+	var du netx.DialerURI
+	if err := du.UnmarshalText([]byte(fmt.Sprintf(
+		"udp+dtlspsk{key=%s,identity=cli,mtu=1200,flightinterval=200ms,resume=true}://%s",
+		testPSK, ln.Addr().String()))); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		conn, err := du.Dial(ctx)
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		if _, err := conn.Write([]byte("ping")); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+		buf := make([]byte, 64)
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if string(buf[:n]) != "ping" {
+			t.Fatalf("echo %d mismatch: %q", i, buf[:n])
+		}
+		_ = conn.Close()
+	}
+}
+
+func TestMemSessionStore(t *testing.T) {
+	s := &memSessionStore{m: make(map[string]dtls.Session), max: 2}
+
+	s.Set([]byte("a"), dtls.Session{ID: []byte{1}, Secret: []byte{2}})
+	got, _ := s.Get([]byte("a"))
+	if len(got.ID) != 1 || got.ID[0] != 1 {
+		t.Fatalf("get mismatch: %+v", got)
+	}
+	if miss, _ := s.Get([]byte("missing")); miss.ID != nil {
+		t.Fatalf("expected zero session for missing key")
+	}
+	s.Set([]byte("b"), dtls.Session{ID: []byte{3}})
+	s.Set([]byte("c"), dtls.Session{ID: []byte{4}})
+	if len(s.m) > 2 {
+		t.Fatalf("store exceeded max: %d", len(s.m))
+	}
+}

--- a/drivers/dtlspsk/session.go
+++ b/drivers/dtlspsk/session.go
@@ -1,0 +1,73 @@
+package dtlspsk
+
+import (
+	"sync"
+
+	"github.com/pion/dtls/v3"
+)
+
+// memSessionStore is a bounded, process-global in-memory dtls.SessionStore used
+// for abbreviated-handshake resumption. It is shared across every dtlspsk
+// listener/dialer in the process so a resumable session survives the per-connect
+// listener teardown on the server side. Entries are capped to bound memory; a
+// peer whose session was evicted simply performs a full handshake.
+type memSessionStore struct {
+	mu  sync.Mutex
+	m   map[string]dtls.Session
+	max int
+}
+
+func (s *memSessionStore) Set(key []byte, v dtls.Session) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.m[string(key)]; !exists && len(s.m) >= s.max {
+		// Bound memory: evict an arbitrary entry (Go randomizes map iteration,
+		// approximating random eviction — losing a ticket only forces a full
+		// handshake, so this is a DoS-safe backstop, not an LRU).
+		for k := range s.m {
+			delete(s.m, k)
+			break
+		}
+	}
+	s.m[string(key)] = dtls.Session{
+		ID:     append([]byte(nil), v.ID...),
+		Secret: append([]byte(nil), v.Secret...),
+	}
+	return nil
+}
+
+func (s *memSessionStore) Get(key []byte) (dtls.Session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[string(key)]
+	if !ok {
+		// A zero Session (ID == nil) signals "no session" to pion's flight
+		// handlers (treated as "no resumption", not an error).
+		return dtls.Session{}, nil
+	}
+	return dtls.Session{
+		ID:     append([]byte(nil), v.ID...),
+		Secret: append([]byte(nil), v.Secret...),
+	}, nil
+}
+
+func (s *memSessionStore) Del(key []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, string(key))
+	return nil
+}
+
+var (
+	sessionStoreOnce sync.Once
+	sessionStore     *memSessionStore
+)
+
+// sharedSessionStore returns the lazily-created, process-global resumption store
+// used by every dtlspsk wrapper that opts in with the `resume` param.
+func sharedSessionStore() dtls.SessionStore {
+	sessionStoreOnce.Do(func() {
+		sessionStore = &memSessionStore{m: make(map[string]dtls.Session), max: 4096}
+	})
+	return sessionStore
+}


### PR DESCRIPTION
## What

Adds optional, additive URI parameters to the `dtls` and `dtlspsk` drivers to speed up and harden the DTLS handshake on lossy / censored paths, plus opt-in session resumption.

| param | drivers | effect |
|-------|---------|--------|
| `mtu` | dtls, dtlspsk | Fragment handshake flights to the path MTU so DTLS records never IP-fragment (fragmented records are disproportionately dropped by middleboxes). Validated 576..1500. |
| `flightinterval` | dtls, dtlspsk | Initial handshake-retransmit interval (pion default 1s); a value near the path RTT recovers a lost flight far faster. |
| `nobackoff` | dtls, dtlspsk | Disable retransmit backoff. |
| `skipcookie` | dtls, dtlspsk (server-only) | Skip the HelloVerifyRequest cookie round-trip (−1 RTT per fresh handshake). Bounded — the handshake can't complete without the pinned cert / PSK. |
| `resume` | dtlspsk (accepted on dtls for forward-compat) | Abbreviated-handshake resumption via a bounded (4096-entry) process-global `SessionStore` shared across listener/dialer instances, so a resumable session survives per-connect listener teardown. |

## Notes

- **Backward compatible**: every param is optional. Untuned URIs parse and behave exactly as before.
- **`resume` caveat**: works on the PSK path. On the cert path, pion/dtls v3.1.2 fails the *full* handshake when a `SessionStore` is set on both ends with separate stores (the separate client/server-process case), so resumption is shipped/documented for `dtlspsk`; the param is still accepted on `dtls` for forward-compat.

## Tests

- **Unit**: param parsing (valid/invalid + server-only guards), a real tuned-handshake echo with an ECDSA cert, and bounded-store eviction. `go test ./...` passes for both driver modules.
- **e2e**: new `DTLS_TUNED` and `DTLSPSK_TUNED` scenarios in `task test:e2e:tun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
