### PR TITLE
cli/tun: embeddable-relay hardening — readiness signal, secret-safe logs, Darwin dial binding, eager handshake retry

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/pedramktb/go-netx/drivers/tlspsk v1.1.1
 	github.com/pedramktb/go-netx/drivers/utls v1.1.1
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.42.0
 )
 
 require (
@@ -35,6 +36,5 @@ require (
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 )

--- a/cli/internal/tun.go
+++ b/cli/internal/tun.go
@@ -73,7 +73,10 @@ func runTun(ctx context.Context, cancel context.CancelFunc, from, to string) err
 	tm := netx.TunMaster[struct{}]{}
 
 	tm.SetRoute(struct{}{}, func(ctx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
-		pconn, err := toURI.Dial(ctx)
+		// dialControl is a no-op except on darwin, where it binds netx's outbound
+		// socket to the primary physical interface (IP_BOUND_IF) so the obfuscation
+		// dial does not loop back into the NEPacketTunnelProvider's tunnel (rx=0).
+		pconn, err := toURI.Dial(ctx, netx.WithDialConfig(net.Dialer{Control: dialControl}))
 		if err != nil {
 			slog.Error("dial tun", "err", err)
 			_ = conn.Close()

--- a/cli/internal/tun.go
+++ b/cli/internal/tun.go
@@ -54,6 +54,30 @@ func tun(cancel context.CancelFunc) *cobra.Command {
 	return cmd
 }
 
+// handshaker is any dialed conn whose security handshake is DEFERRED to the first
+// I/O (pion *dtls.Conn, stdlib *tls.Conn). pion's lazy Handshake() runs under an
+// uncancellable context.Background() at first Read/Write, and pion's UDP listener
+// keys conns by 5-tuple — so WireGuard's handshake-init retransmits from the same
+// source port hit the SAME (stalled) conn and never re-enter the dial handler. A
+// first handshake that stalls/fails is then permanent until a full client
+// reconnect ("first connect dark, 2nd attempt works"). Driving the handshake
+// eagerly under a bounded, cancellable ctx (below) turns that silent stall into a
+// fast, retryable dial error. AES-GCM/frame/plain conns don't implement this and
+// have no blocking handshake, so the assertion simply no-ops for them.
+type handshaker interface {
+	HandshakeContext(ctx context.Context) error
+}
+
+const (
+	// 1 initial + 2 retries. Per-attempt 4s comfortably covers a DTLS Certificate
+	// flight on a lossy/censored path; worst case (4+0.25+4+0.25+4 ≈ 12.5s) stays
+	// under the Dart-side netx/wg start timeout (15s) so a genuinely dead path
+	// returns a clean transient error to the establishment-retry layer, not a hang.
+	dialHandshakeAttempts = 3
+	dialHandshakeTimeout  = 4 * time.Second
+	dialHandshakeBackoff  = 250 * time.Millisecond
+)
+
 func runTun(ctx context.Context, cancel context.CancelFunc, from, to string) error {
 	var fromURI netx.ListenerURI
 	var toURI netx.DialerURI
@@ -73,12 +97,50 @@ func runTun(ctx context.Context, cancel context.CancelFunc, from, to string) err
 	tm := netx.TunMaster[struct{}]{}
 
 	tm.SetRoute(struct{}{}, func(ctx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
-		// dialControl is a no-op except on darwin, where it binds netx's outbound
-		// socket to the primary physical interface (IP_BOUND_IF) so the obfuscation
-		// dial does not loop back into the NEPacketTunnelProvider's tunnel (rx=0).
-		pconn, err := toURI.Dial(ctx, netx.WithDialConfig(net.Dialer{Control: dialControl}))
-		if err != nil {
-			slog.Error("dial tun", "err", err)
+		var pconn net.Conn
+		var lastErr error
+		for attempt := 1; attempt <= dialHandshakeAttempts; attempt++ {
+			// NetxInterrupt (ctx cancel) aborts immediately, even between attempts.
+			if err := ctx.Err(); err != nil {
+				lastErr = err
+				break
+			}
+			// dialControl is a no-op except on darwin, where it binds netx's outbound
+			// socket to the primary physical interface (IP_BOUND_IF) so the obfuscation
+			// dial does not loop back into the NEPacketTunnelProvider's tunnel (rx=0).
+			// Re-applied on EVERY attempt so the physical-iface bind survives retries.
+			c, err := toURI.Dial(ctx, netx.WithDialConfig(net.Dialer{Control: dialControl}))
+			if err != nil {
+				lastErr = err
+				slog.Warn("dial tun", "attempt", attempt, "err", err)
+			} else if hs, ok := c.(handshaker); ok {
+				// Drive the deferred DTLS/TLS handshake eagerly under a bounded,
+				// cancellable ctx instead of letting it run later under
+				// context.Background() at first I/O (see handshaker above).
+				hctx, cancelHS := context.WithTimeout(ctx, dialHandshakeTimeout)
+				err = hs.HandshakeContext(hctx)
+				cancelHS()
+				if err != nil {
+					_ = c.Close()
+					lastErr = err
+					slog.Warn("dial tun handshake", "attempt", attempt, "err", err)
+				} else {
+					pconn = c
+					break
+				}
+			} else {
+				pconn = c // no deferred handshake (aes/frame/plain) — done
+				break
+			}
+			if attempt < dialHandshakeAttempts {
+				select {
+				case <-ctx.Done():
+				case <-time.After(dialHandshakeBackoff):
+				}
+			}
+		}
+		if pconn == nil {
+			slog.Error("dial tun", "err", lastErr)
 			_ = conn.Close()
 			return false, ctx, netx.Tun{}
 		}

--- a/cli/internal/tun.go
+++ b/cli/internal/tun.go
@@ -70,15 +70,6 @@ func runTun(ctx context.Context, cancel context.CancelFunc, from, to string) err
 	}
 	defer ln.Close()
 
-	// NETX_READY is a stable, secret-free "listener bound" marker emitted the
-	// instant the listener is bound — the socket is already accepting and buffering
-	// datagrams here, before Serve runs, so a packet arriving right after it is not
-	// dropped. The c-shared library forwards slog output to the embedding process,
-	// which latches on this token to start forwarding the moment the relay is ready
-	// instead of waiting out a fixed startup timeout. It is an external contract:
-	// keep the token bare and its attributes secret-free.
-	slog.Info("NETX_READY", "listen", ln.Addr().String())
-
 	tm := netx.TunMaster[struct{}]{}
 
 	tm.SetRoute(struct{}{}, func(ctx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
@@ -99,10 +90,12 @@ func runTun(ctx context.Context, cancel context.CancelFunc, from, to string) err
 		}
 	}()
 
-	// from/to carry the full URI scheme, which on the listener side can include
-	// private key material (e.g. key=<hex>); log it only at debug so the default
-	// info stream forwarded to embedders stays secret-free.
-	slog.Debug("netx tun started", "from", from, "to", to)
+	// Embedders (the c-shared library forwards info-level slog output to a C
+	// callback) latch on this line to know the relay is bound and serving.
+	// Redacted() masks secret param values with driver-supplied protocol-standard
+	// fingerprints, so the protocol chain stays visible without leaking key
+	// material.
+	slog.Info("netx tun started", "listen", ln.Addr().String(), "from", fromURI.Redacted(), "to", toURI.Redacted())
 
 	<-ctx.Done()
 	shutdownCtx, stop := context.WithTimeout(context.Background(), 3*time.Second)

--- a/cli/internal/tun.go
+++ b/cli/internal/tun.go
@@ -70,6 +70,15 @@ func runTun(ctx context.Context, cancel context.CancelFunc, from, to string) err
 	}
 	defer ln.Close()
 
+	// NETX_READY is a stable, secret-free "listener bound" marker emitted the
+	// instant the listener is bound — the socket is already accepting and buffering
+	// datagrams here, before Serve runs, so a packet arriving right after it is not
+	// dropped. The c-shared library forwards slog output to the embedding process,
+	// which latches on this token to start forwarding the moment the relay is ready
+	// instead of waiting out a fixed startup timeout. It is an external contract:
+	// keep the token bare and its attributes secret-free.
+	slog.Info("NETX_READY", "listen", ln.Addr().String())
+
 	tm := netx.TunMaster[struct{}]{}
 
 	tm.SetRoute(struct{}{}, func(ctx context.Context, conn net.Conn) (bool, context.Context, netx.Tun) {
@@ -90,7 +99,10 @@ func runTun(ctx context.Context, cancel context.CancelFunc, from, to string) err
 		}
 	}()
 
-	slog.Info("netx tun started", "listen", ln.Addr().String(), "from", from, "to", to)
+	// from/to carry the full URI scheme, which on the listener side can include
+	// private key material (e.g. key=<hex>); log it only at debug so the default
+	// info stream forwarded to embedders stays secret-free.
+	slog.Debug("netx tun started", "from", from, "to", to)
 
 	<-ctx.Done()
 	shutdownCtx, stop := context.WithTimeout(context.Background(), 3*time.Second)

--- a/cli/internal/tun_darwin.go
+++ b/cli/internal/tun_darwin.go
@@ -1,0 +1,86 @@
+//go:build darwin
+
+package internal
+
+import (
+	"log/slog"
+	"net"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// dialControl binds netx's outbound socket to the primary physical interface.
+//
+// On macOS, netx runs INSIDE the NEPacketTunnelProvider, whose own sockets are
+// scoped to the tunnel it serves. Without an explicit binding, netx's UDP
+// socket to the obfuscation server loops back into the tunnel and the WireGuard
+// handshake never completes (rx=0). wireguard-go binds its socket to the
+// physical interface via IP_BOUND_IF; this does the same for netx. Fail-open:
+// if no usable interface is found or the bind fails, the dial proceeds unbound
+// rather than erroring.
+func dialControl(network, address string, c syscall.RawConn) error {
+	idx, ok := primaryPhysicalIfaceIndex()
+	if !ok {
+		return nil
+	}
+	_ = c.Control(func(fd uintptr) {
+		// IP_BOUND_IF / IPV6_BOUND_IF take an interface index. Best-effort for
+		// both families; setting the v6 option on a v4 socket simply no-ops.
+		_ = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_BOUND_IF, idx)
+		_ = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_BOUND_IF, idx)
+	})
+	slog.Info("netx: bound dial socket to physical interface", "network", network, "ifindex", idx)
+	return nil
+}
+
+// primaryPhysicalIfaceIndex returns the index of the lowest-index, up,
+// non-loopback en* interface that carries a usable (non-link-local) IPv4
+// address — i.e. the Mac's primary physical / Wi-Fi interface.
+func primaryPhysicalIfaceIndex() (int, bool) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return 0, false
+	}
+	best := -1
+	for _, ifi := range ifaces {
+		if ifi.Flags&net.FlagUp == 0 || ifi.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if !strings.HasPrefix(ifi.Name, "en") {
+			continue
+		}
+		addrs, err := ifi.Addrs()
+		if err != nil {
+			continue
+		}
+		hasV4 := false
+		for _, a := range addrs {
+			var ip net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+			if ip.To4() != nil {
+				hasV4 = true
+				break
+			}
+		}
+		if !hasV4 {
+			continue
+		}
+		if best == -1 || ifi.Index < best {
+			best = ifi.Index
+		}
+	}
+	if best == -1 {
+		return 0, false
+	}
+	return best, true
+}

--- a/cli/internal/tun_darwin.go
+++ b/cli/internal/tun_darwin.go
@@ -5,22 +5,32 @@ package internal
 import (
 	"log/slog"
 	"net"
+	"runtime"
 	"strings"
 	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
-// dialControl binds netx's outbound socket to the primary physical interface.
+// dialControl binds netx's outbound socket to a physical interface — but ONLY on
+// iOS. There, netx runs INSIDE the NEPacketTunnelProvider, whose sockets are
+// scoped to the tunnel; without the bind, netx's obfuscation-server socket loops
+// back into the tunnel and the WireGuard handshake never completes (rx=0).
 //
-// On macOS, netx runs INSIDE the NEPacketTunnelProvider, whose own sockets are
-// scoped to the tunnel it serves. Without an explicit binding, netx's UDP
-// socket to the obfuscation server loops back into the tunnel and the WireGuard
-// handshake never completes (rx=0). wireguard-go binds its socket to the
-// physical interface via IP_BOUND_IF; this does the same for netx. Fail-open:
-// if no usable interface is found or the bind fails, the dial proceeds unbound
-// rather than erroring.
+// On macOS, netx runs in the root HELPER DAEMON, OUTSIDE any tunnel, so its
+// egress already follows the kernel routing table (the daemon excludes the
+// server /32 from the utun). Binding here is not just unnecessary — it is
+// HARMFUL: primaryPhysicalIfaceIndex's "lowest-index up interface" guess can land
+// on a STALE or secondary interface after a network switch (a USB-ethernet /
+// Thunderbolt dock / lingering old Wi-Fi), pinning the socket to an interface
+// whose subnet no longer matches the server route. The kernel then drops every
+// packet — tx climbs, rx stays ~0, the handshake never completes (the macOS
+// post-network-switch dead-tunnel bug). So macOS lets the route table decide,
+// exactly like Linux/Windows where dialControl is already a no-op (tun_other.go).
 func dialControl(network, address string, c syscall.RawConn) error {
+	if runtime.GOOS != "ios" {
+		return nil
+	}
 	idx, ok := primaryPhysicalIfaceIndex()
 	if !ok {
 		return nil
@@ -36,8 +46,13 @@ func dialControl(network, address string, c syscall.RawConn) error {
 }
 
 // primaryPhysicalIfaceIndex returns the index of the lowest-index, up,
-// non-loopback en* interface that carries a usable (non-link-local) IPv4
-// address — i.e. the Mac's primary physical / Wi-Fi interface.
+// non-loopback, NON-TUNNEL interface that carries a usable (non-link-local) IPv4
+// address — the device's active physical uplink. Used on iOS only (see
+// dialControl). It must include cellular (pdp_ipN), not just Wi-Fi (enN): a
+// Wi-Fi->cellular switch leaves only pdp_ip0 up, and an en-only match would find
+// nothing -> the dial proceeds unbound -> netx loops into the tunnel (rx=0).
+// Tunnel interfaces (utun/ipsec/ppp/tap) are excluded so we never bind to our own
+// tunnel (whose utun carries a usable 10.x address).
 func primaryPhysicalIfaceIndex() (int, bool) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -48,7 +63,9 @@ func primaryPhysicalIfaceIndex() (int, bool) {
 		if ifi.Flags&net.FlagUp == 0 || ifi.Flags&net.FlagLoopback != 0 {
 			continue
 		}
-		if !strings.HasPrefix(ifi.Name, "en") {
+		n := ifi.Name
+		if strings.HasPrefix(n, "utun") || strings.HasPrefix(n, "ipsec") ||
+			strings.HasPrefix(n, "ppp") || strings.HasPrefix(n, "tap") {
 			continue
 		}
 		addrs, err := ifi.Addrs()

--- a/cli/internal/tun_other.go
+++ b/cli/internal/tun_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package internal
+
+import "syscall"
+
+// dialControl is a no-op off darwin. On macOS it binds netx's outbound socket
+// to the primary physical interface (see tun_darwin.go); on Linux/Windows netx
+// runs as its own process, so the socket is not scoped to the tunnel and no
+// binding is needed.
+func dialControl(network, address string, c syscall.RawConn) error {
+	return nil
+}

--- a/cli/internal/tun_test.go
+++ b/cli/internal/tun_test.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a goroutine-safe writer: runTun emits on its own goroutine while
+// the test reads from another.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// readyLine returns the first captured line containing the NETX_READY marker, or
+// "" if none has been emitted yet.
+func (b *syncBuffer) readyLine() string {
+	for _, line := range strings.Split(b.String(), "\n") {
+		if strings.Contains(line, "NETX_READY") {
+			return line
+		}
+	}
+	return ""
+}
+
+// TestRunTunEmitsReadyMarker asserts that, on a healthy start, runTun emits the
+// secret-free "NETX_READY" listener-bound marker through the out writer the
+// moment the listener is bound — the signal the embedding client latches on to
+// start forwarding without waiting out a fixed startup timeout. It exercises the
+// full slog -> cfg.out chain (root.go points slog's default handler at cfg.out),
+// which is exactly what the c-shared library wraps into the C callback.
+//
+// Not parallel: Run installs a process-global slog default, restored on cleanup.
+func TestRunTunEmitsReadyMarker(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	out := &syncBuffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan int, 1)
+	go func() {
+		// --from binds an ephemeral loopback UDP port; --to is dialed lazily on the
+		// first packet, so no reachable upstream is needed for the bind/marker.
+		done <- Run(ctx, cancel,
+			WithArgs([]string{"tun",
+				"--from", "udp://127.0.0.1:0",
+				"--to", "udp://127.0.0.1:9999",
+			}),
+			WithOut(out),
+			WithErr(out),
+		)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for out.readyLine() == "" {
+		if time.Now().After(deadline) {
+			t.Fatalf("NETX_READY not emitted within timeout; captured:\n%s", out.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if line := out.readyLine(); !strings.Contains(line, "listen=") {
+		t.Errorf("NETX_READY line missing listen= address: %q", line)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Errorf("Run returned non-zero exit code %d after clean cancel", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s after cancel")
+	}
+}

--- a/cli/internal/tun_test.go
+++ b/cli/internal/tun_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	_ "github.com/pedramktb/go-netx/drivers/aesgcm"
 )
 
 // syncBuffer is a goroutine-safe writer: runTun emits on its own goroutine while
@@ -29,41 +31,43 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-// readyLine returns the first captured line containing the NETX_READY marker, or
-// "" if none has been emitted yet.
-func (b *syncBuffer) readyLine() string {
-	for _, line := range strings.Split(b.String(), "\n") {
-		if strings.Contains(line, "NETX_READY") {
+// findLine returns the first captured line containing needle, or "" if none.
+func (b *syncBuffer) findLine(needle string) string {
+	for line := range strings.SplitSeq(b.String(), "\n") {
+		if strings.Contains(line, needle) {
 			return line
 		}
 	}
 	return ""
 }
 
-// TestRunTunEmitsReadyMarker asserts that, on a healthy start, runTun emits the
-// secret-free "NETX_READY" listener-bound marker through the out writer the
-// moment the listener is bound — the signal the embedding client latches on to
-// start forwarding without waiting out a fixed startup timeout. It exercises the
-// full slog -> cfg.out chain (root.go points slog's default handler at cfg.out),
-// which is exactly what the c-shared library wraps into the C callback.
+// TestRunTunStartedLine asserts that the info-level "netx tun started" line —
+// which the c-shared library forwards to the embedder's log callback as the
+// "relay is bound and serving" signal — carries the listen address and the
+// protocol chain, and that secret param values are replaced with their
+// driver-supplied fingerprints rather than the raw key material.
+//
+// Exercises the full slog -> cfg.out chain (root.go points slog's default
+// handler at cfg.out), which is exactly what the c-shared library wraps.
 //
 // Not parallel: Run installs a process-global slog default, restored on cleanup.
-func TestRunTunEmitsReadyMarker(t *testing.T) {
+func TestRunTunStartedLine(t *testing.T) {
 	prev := slog.Default()
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
+	const keyHex = "00112233445566778899aabbccddeeff"
 	out := &syncBuffer{}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	done := make(chan int, 1)
 	go func() {
-		// --from binds an ephemeral loopback UDP port; --to is dialed lazily on the
-		// first packet, so no reachable upstream is needed for the bind/marker.
+		// --from binds an ephemeral loopback UDP port; --to is dialed lazily on
+		// the first packet, so no reachable upstream is needed.
 		done <- Run(ctx, cancel,
 			WithArgs([]string{"tun",
-				"--from", "udp://127.0.0.1:0",
-				"--to", "udp://127.0.0.1:9999",
+				"--from", "udp+aesgcm{key=" + keyHex + "}://127.0.0.1:0",
+				"--to", "udp+aesgcm{key=" + keyHex + "}://127.0.0.1:9999",
 			}),
 			WithOut(out),
 			WithErr(out),
@@ -71,15 +75,25 @@ func TestRunTunEmitsReadyMarker(t *testing.T) {
 	}()
 
 	deadline := time.Now().Add(5 * time.Second)
-	for out.readyLine() == "" {
+	for out.findLine("netx tun started") == "" {
 		if time.Now().After(deadline) {
-			t.Fatalf("NETX_READY not emitted within timeout; captured:\n%s", out.String())
+			t.Fatalf("started line not emitted within timeout; captured:\n%s", out.String())
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	if line := out.readyLine(); !strings.Contains(line, "listen=") {
-		t.Errorf("NETX_READY line missing listen= address: %q", line)
+	line := out.findLine("netx tun started")
+	if !strings.Contains(line, "listen=") {
+		t.Errorf("started line missing listen= address: %q", line)
+	}
+	if strings.Contains(line, keyHex) {
+		t.Errorf("raw key material leaked into started line: %q", line)
+	}
+	if !strings.Contains(line, "aesgcm") {
+		t.Errorf("protocol chain missing from started line: %q", line)
+	}
+	if !strings.Contains(line, "key=REDACTED(sha256=") {
+		t.Errorf("redacted fingerprint missing from started line: %q", line)
 	}
 
 	cancel()

--- a/drivers/aesgcm/aesgcm.go
+++ b/drivers/aesgcm/aesgcm.go
@@ -1,6 +1,7 @@
 package aesgcm
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -33,10 +34,15 @@ func init() {
 		connToConn := func(c net.Conn) (net.Conn, error) {
 			return aesgcmproto.NewAESGCMConn(c, aeskey)
 		}
+		keySum := sha256.Sum256(aeskey)
 		return netx.Wrapper{
 			Name:     "aesgcm",
 			Params:   params,
 			Listener: listener,
+			SecretParams: []netx.SecretParam{{
+				Name:        "key",
+				Fingerprint: "sha256=" + colonHex(keySum[:8]),
+			}},
 			ListenerToListener: func(l net.Listener) (net.Listener, error) {
 				return netx.ConnWrapListener(l, connToConn)
 			},
@@ -46,4 +52,17 @@ func init() {
 			ConnToConn: connToConn,
 		}, nil
 	})
+}
+
+// colonHex formats b as colon-separated hex pairs (e.g. "ab:cd:ef").
+func colonHex(b []byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, 0, len(b)*3-1)
+	for i, x := range b {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hexdigits[x>>4], hexdigits[x&0x0f])
+	}
+	return string(out)
 }

--- a/drivers/dtls/dtls.go
+++ b/drivers/dtls/dtls.go
@@ -48,10 +48,15 @@ func init() {
 				return netx.Wrapper{}, fmt.Errorf("uri: invalid dtls certificate: %w", err)
 			}
 			cfg.Certificates = []tls.Certificate{certificate}
+			certSum := sha256.Sum256(certificate.Certificate[0])
 			return netx.Wrapper{
 				Name:     "dtls",
 				Params:   params,
 				Listener: listener,
+				SecretParams: []netx.SecretParam{{
+					Name:        "key",
+					Fingerprint: "sha256=" + colonHex(certSum[:8]),
+				}},
 				ListenerToListener: func(l net.Listener) (net.Listener, error) {
 					return dtls.NewListener(dtlsnet.PacketListenerFromListener(l), cfg)
 				},
@@ -87,6 +92,19 @@ func init() {
 				}}, nil
 		}
 	})
+}
+
+// colonHex formats b as colon-separated hex pairs (e.g. "ab:cd:ef").
+func colonHex(b []byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, 0, len(b)*3-1)
+	for i, x := range b {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hexdigits[x>>4], hexdigits[x&0x0f])
+	}
+	return string(out)
 }
 
 func spkiVerifier(certPEM []byte) (func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error, error) {

--- a/drivers/dtlspsk/dtlspsk.go
+++ b/drivers/dtlspsk/dtlspsk.go
@@ -1,6 +1,7 @@
 package dtlspsk
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -42,11 +43,17 @@ func init() {
 			CipherSuites:       []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_GCM_SHA256},
 			InsecureSkipVerify: true,
 		}
+		pskSum := sha256.Sum256(psk)
+		secretParams := []netx.SecretParam{{
+			Name:        "key",
+			Fingerprint: "sha256=" + colonHex(pskSum[:8]),
+		}}
 		if listener {
 			return netx.Wrapper{
-				Name:     "dtlspsk",
-				Params:   params,
-				Listener: listener,
+				Name:         "dtlspsk",
+				Params:       params,
+				Listener:     listener,
+				SecretParams: secretParams,
 				ListenerToListener: func(l net.Listener) (net.Listener, error) {
 					return dtls.NewListener(dtlsnet.PacketListenerFromListener(l), cfg)
 				},
@@ -55,9 +62,10 @@ func init() {
 				}}, nil
 		} else {
 			return netx.Wrapper{
-				Name:     "dtlspsk",
-				Params:   params,
-				Listener: listener,
+				Name:         "dtlspsk",
+				Params:       params,
+				Listener:     listener,
+				SecretParams: secretParams,
 				DialerToDialer: func(f netx.Dialer) (netx.Dialer, error) {
 					return netx.ConnWrapDialer(f, func(c net.Conn) (net.Conn, error) {
 						return dtls.Client(dtlsnet.PacketConnFromConn(c), c.RemoteAddr(), cfg)
@@ -68,4 +76,17 @@ func init() {
 				}}, nil
 		}
 	})
+}
+
+// colonHex formats b as colon-separated hex pairs (e.g. "ab:cd:ef").
+func colonHex(b []byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, 0, len(b)*3-1)
+	for i, x := range b {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hexdigits[x>>4], hexdigits[x&0x0f])
+	}
+	return string(out)
 }

--- a/drivers/ssh/ssh.go
+++ b/drivers/ssh/ssh.go
@@ -2,6 +2,8 @@ package ssh
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -42,6 +44,7 @@ func init() {
 				return netx.Wrapper{}, fmt.Errorf("uri: unknown ssh parameter %q", key)
 			}
 		}
+		secretParams := sshSecretParams(sshkey)
 		if listener {
 			cfg := &ssh.ServerConfig{}
 			if sshkey == nil {
@@ -68,9 +71,10 @@ func init() {
 				return netx.Wrapper{}, fmt.Errorf("uri: ssh server requires pubkey or pass parameter")
 			}
 			return netx.Wrapper{
-				Name:     "ssh",
-				Params:   params,
-				Listener: listener,
+				Name:         "ssh",
+				Params:       params,
+				Listener:     listener,
+				SecretParams: secretParams,
 				ListenerToListener: func(l net.Listener) (net.Listener, error) {
 					return netx.ConnWrapListener(l, func(c net.Conn) (net.Conn, error) {
 						return sshproto.NewServerConn(c, cfg)
@@ -100,9 +104,10 @@ func init() {
 				return netx.Wrapper{}, fmt.Errorf("uri: ssh client requires key or pass parameter")
 			}
 			return netx.Wrapper{
-				Name:     "ssh",
-				Params:   params,
-				Listener: listener,
+				Name:         "ssh",
+				Params:       params,
+				Listener:     listener,
+				SecretParams: secretParams,
 				DialerToDialer: func(f netx.Dialer) (netx.Dialer, error) {
 					return netx.ConnWrapDialer(f, func(c net.Conn) (net.Conn, error) {
 						return sshproto.NewClientConn(c, cfg)
@@ -113,4 +118,22 @@ func init() {
 				}}, nil
 		}
 	})
+}
+
+// sshSecretParams declares the sensitive params on an ssh Wrapper:
+//   - "key": private key — fingerprinted as the matching public key's standard
+//     SSH fingerprint ("SHA256:<base64-of-sha256-of-wire-format>"), the same
+//     value `ssh-keygen -lf` prints.
+//   - "pass": password — bare REDACTED. A fingerprint of a low-entropy secret
+//     is brute-forceable, so no payload is exposed.
+func sshSecretParams(signer ssh.Signer) []netx.SecretParam {
+	out := []netx.SecretParam{{Name: "pass"}}
+	if signer != nil {
+		sum := sha256.Sum256(signer.PublicKey().Marshal())
+		out = append(out, netx.SecretParam{
+			Name:        "key",
+			Fingerprint: "SHA256:" + base64.RawStdEncoding.EncodeToString(sum[:]),
+		})
+	}
+	return out
 }

--- a/drivers/tls/tls.go
+++ b/drivers/tls/tls.go
@@ -49,10 +49,18 @@ func init() {
 				return netx.Wrapper{}, fmt.Errorf("uri: invalid tls certificate: %w", err)
 			}
 			cfg.Certificates = []tls.Certificate{certificate}
+			certSum := sha256.Sum256(certificate.Certificate[0])
 			return netx.Wrapper{
 				Name:     "tls",
 				Params:   params,
 				Listener: listener,
+				SecretParams: []netx.SecretParam{{
+					Name: "key",
+					// Fingerprint of the paired cert (SHA-256 of DER) — matches
+					// `openssl x509 -fingerprint -sha256` and browser cert dialogs.
+					// A matching key on the peer must pair with this cert.
+					Fingerprint: "sha256=" + colonHex(certSum[:8]),
+				}},
 				ListenerToListener: func(l net.Listener) (net.Listener, error) {
 					return tls.NewListener(l, cfg), nil
 				},
@@ -88,6 +96,19 @@ func init() {
 				}}, nil
 		}
 	})
+}
+
+// colonHex formats b as colon-separated hex pairs (e.g. "ab:cd:ef").
+func colonHex(b []byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, 0, len(b)*3-1)
+	for i, x := range b {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hexdigits[x>>4], hexdigits[x&0x0f])
+	}
+	return string(out)
 }
 
 func spkiVerifier(certPEM []byte) (func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error, error) {

--- a/drivers/tlspsk/tlspsk.go
+++ b/drivers/tlspsk/tlspsk.go
@@ -1,6 +1,7 @@
 package tlspsk
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
@@ -45,13 +46,19 @@ func init() {
 			CipherSuites:       []uint16{tlspks.TLS_PSK_WITH_AES_256_CBC_SHA},
 			InsecureSkipVerify: true,
 		}
+		pskSum := sha256.Sum256(psk)
+		secretParams := []netx.SecretParam{{
+			Name:        "key",
+			Fingerprint: "sha256=" + colonHex(pskSum[:8]),
+		}}
 		if listener {
 			// Provide dummy Certificates to make tlspsk happy on server side
 			cfg.Certificates = dummyCert()
 			return netx.Wrapper{
-				Name:     "tlspsk",
-				Params:   params,
-				Listener: listener,
+				Name:         "tlspsk",
+				Params:       params,
+				Listener:     listener,
+				SecretParams: secretParams,
 				ListenerToListener: func(l net.Listener) (net.Listener, error) {
 					return netx.ConnWrapListener(l, func(c net.Conn) (net.Conn, error) {
 						return tlswithpks.Server(c, cfg), nil
@@ -62,9 +69,10 @@ func init() {
 				}}, nil
 		} else {
 			return netx.Wrapper{
-				Name:     "tlspsk",
-				Params:   params,
-				Listener: listener,
+				Name:         "tlspsk",
+				Params:       params,
+				Listener:     listener,
+				SecretParams: secretParams,
 				DialerToDialer: func(f netx.Dialer) (netx.Dialer, error) {
 					return netx.ConnWrapDialer(f, func(c net.Conn) (net.Conn, error) {
 						return tlswithpks.Client(c, cfg), nil
@@ -75,6 +83,19 @@ func init() {
 				}}, nil
 		}
 	})
+}
+
+// colonHex formats b as colon-separated hex pairs (e.g. "ab:cd:ef").
+func colonHex(b []byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, 0, len(b)*3-1)
+	for i, x := range b {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hexdigits[x>>4], hexdigits[x&0x0f])
+	}
+	return string(out)
 }
 
 // dummyCert returns a self-signed certificate for use in tls-psk server mode. (ed25519)

--- a/scheme.go
+++ b/scheme.go
@@ -62,6 +62,16 @@ func (s Scheme) String() string {
 	return str
 }
 
+// Redacted is like String but renders the wrapper chain via Wrappers.Redacted,
+// masking sensitive param values declared by each driver's SecretParams.
+func (s Scheme) Redacted() string {
+	str := s.Transport.String()
+	if len(s.Wrappers) > 0 {
+		str += "+" + s.Wrappers.Redacted()
+	}
+	return str
+}
+
 func (s Scheme) MarshalText() ([]byte, error) {
 	return []byte(s.String()), nil
 }

--- a/uri.go
+++ b/uri.go
@@ -36,6 +36,13 @@ func (u URI) String() string {
 	return u.Scheme.String() + "://" + u.Addr
 }
 
+// Redacted is like String but renders the scheme via Scheme.Redacted, masking
+// sensitive param values. Use Redacted whenever a URI is rendered into a
+// user-visible stream; String remains round-trippable through UnmarshalText.
+func (u URI) Redacted() string {
+	return u.Scheme.Redacted() + "://" + u.Addr
+}
+
 func (u URI) MarshalText() ([]byte, error) {
 	return []byte(u.String()), nil
 }

--- a/wrap.go
+++ b/wrap.go
@@ -64,6 +64,17 @@ func (ws Wrappers) String() string {
 	return strings.Join(strs, "+")
 }
 
+// Redacted is like String but masks values of params declared in each
+// Wrapper.SecretParams. Use it whenever a Wrappers chain is rendered into a
+// user-visible stream (logs, errors surfaced to embedders).
+func (ws Wrappers) Redacted() string {
+	strs := make([]string, len(ws))
+	for i, w := range ws {
+		strs[i] = w.Redacted()
+	}
+	return strings.Join(strs, "+")
+}
+
 func (ws Wrappers) MarshalText() ([]byte, error) {
 	return []byte(ws.String()), nil
 }
@@ -120,6 +131,11 @@ type Wrapper struct {
 	Name     string
 	Params   map[string]string
 	Listener bool
+
+	// SecretParams declares param keys in Params whose values are sensitive
+	// (private keys, passphrases). Redacted() masks them; String() does not.
+	// Keep String() output away from user-visible logs. See SecretParam.
+	SecretParams []SecretParam
 
 	ListenerToListener func(net.Listener) (net.Listener, error)
 	ListenerToConn     func(net.Listener) (net.Conn, error)
@@ -254,9 +270,48 @@ func (w Wrapper) Apply(v any) (any, error) {
 	return nil, fmt.Errorf("wrapper %q: incompatible type %T", w.Name, v)
 }
 
+// SecretParam declares one sensitive param on a Wrapper. See Wrapper.SecretParams.
+type SecretParam struct {
+	Name string
+	// Fingerprint is the payload rendered inside REDACTED(...). Drivers
+	// compute it once at parse time in their protocol's standard form (e.g.
+	// "SHA256:..." for SSH, "sha256=AB:CD:..." for TLS) so operators can
+	// cross-check against ssh-keygen/openssl/browser output. Leave empty for
+	// low-entropy secrets (e.g. passwords) where a fingerprint would be
+	// brute-forceable — the value renders as a bare REDACTED.
+	Fingerprint string
+}
+
 func (w Wrapper) String() string {
+	return w.render(nil)
+}
+
+// Redacted is like String but renders the value of each param declared in
+// SecretParams via its Fingerprint function. The output is not round-trippable
+// through UnmarshalText. Use Redacted whenever a Wrapper is rendered into a
+// user-visible stream (logs, errors surfaced to embedders).
+func (w Wrapper) Redacted() string {
+	if len(w.SecretParams) == 0 {
+		return w.String()
+	}
+	secrets := make(map[string]SecretParam, len(w.SecretParams))
+	for _, sp := range w.SecretParams {
+		secrets[sp.Name] = sp
+	}
+	return w.render(secrets)
+}
+
+func (w Wrapper) render(secrets map[string]SecretParam) string {
 	pairs := make([]string, 0, len(w.Params))
 	for k, v := range w.Params {
+		if sp, ok := secrets[k]; ok {
+			if sp.Fingerprint == "" {
+				pairs = append(pairs, k+"=REDACTED")
+			} else {
+				pairs = append(pairs, k+"=REDACTED("+sp.Fingerprint+")")
+			}
+			continue
+		}
 		pairs = append(pairs, k+"="+v)
 	}
 	if len(pairs) > 0 {


### PR DESCRIPTION
## Summary

Five focused changes that harden `cli/tun` (and the c-archive FFI) for use as an **embedded relay** — the Ironlink VPN client links `libnetx` as a cgo `c-archive` and forwards netx's `slog` output to a user-visible log stream. Each is isolated to the `cli/tun` path + drivers; the Darwin-specific socket binding is behind `//go:build darwin` with a `!darwin` no-op, so **Linux/Windows/Android relay behavior is unchanged**. No wire-protocol or FFI-signature changes.

These have been running in production across iOS, macOS, Android, Linux and Windows. I'd love to get them upstream so a tagged release can propagate the fixes to every platform build (I can only cross-compile Darwin locally). Happy to split into separate PRs or adjust naming/defaults to your preference.

Tests: `go test ./...` green in both the root and `cli/` modules; `go vet`/`gofmt` clean.

---

### 1. Listener-bound readiness signal + secret-free info logs (`27e20b0`)

**Problem:** on a healthy start `Netx()` never returns — it binds the loopback listener and parks until interrupt — so an embedder has no positive "listener bound" signal and must wait out a fixed startup timeout (~6 s) on every connect before it starts forwarding. Separately, the startup line logged the full `--from`/`--to` scheme at info level, which on the listener side can contain private-key material (`key=<hex>`); the c-archive forwards info logs to the embedder's user-visible stream.

**Solution:** emit a stable, secret-free readiness marker the instant the listener is bound (before `Serve`) — the socket is already accepting/buffering datagrams, so forwarding on this signal can't hit a closed port; the client latches on the token and starts immediately (~6 s saved per connect). The scheme detail with key material is demoted to debug.

### 2. URI secret redaction with driver-supplied fingerprints (`866c054`)

**Problem:** any sensitive URI param (private keys, PSKs, passwords) logged at info would leak into the embedder's user-visible log stream.

**Solution:** an opt-in redaction path on `URI`/`Scheme`/`Wrappers`/`Wrapper`: `netx.SecretParam{Name, Fingerprint}` declares which params are sensitive, and `Redacted()` renders the chain with secret values replaced by `REDACTED(<fingerprint>)` while `String()` stays round-trippable. Each driver computes its fingerprint at parse time in the protocol's standard form (e.g. `tls`/`dtls` → `sha256=` colon-hex of the cert DER, matching `openssl x509 -fingerprint -sha256`; `aesgcm`/`*psk` → sha256 of decoded key bytes; `ssh` → `SHA256:<base64>`), so operators can cross-check without seeing the secret.

### 3. Bind the upstream dial socket to the physical interface on Darwin (`e7bdcb3`)

**Problem:** on iOS/macOS netx runs *inside* the `NEPacketTunnelProvider`, whose sockets are scoped to the tunnel it serves — so netx's outbound UDP socket to the obfuscation server loops back into the WireGuard tunnel and the handshake never completes (`rx=0`). (`wireguard-go` avoids this with `IP_BOUND_IF`.)

**Solution:** pass a `net.Dialer.Control` that binds the upstream dial socket to the primary physical interface on Darwin (`tun_darwin.go`), with a `!darwin` no-op (`tun_other.go`) so Linux/Windows/Android — where netx is its own process and not tunnel-scoped — are unchanged. Fail-open: if no usable interface is found the dial proceeds unbound. (Upstreams a fix previously carried as a client-local patch.)

### 4. Bind only on iOS; broaden iOS interface detection to include cellular (`357edee`)

**Problem:** the macOS helper-daemon model runs netx *outside* the tunnel (egress already follows the route table, server `/32` excluded from the utun), so the `IP_BOUND_IF` bind is unnecessary **and harmful** there: after a network switch the "lowest-index up `enN`" guess can pin the socket to a stale/secondary interface (USB-ethernet, Thunderbolt dock, lingering Wi-Fi) whose subnet no longer matches the server route → the kernel drops every packet (tx climbs, rx≈0, WG handshake never completes). Also, the `enN`-only match found nothing during a Wi-Fi→cellular switch (only `pdp_ip0` up), so the dial proceeded unbound and looped into the tunnel.

**Solution:** bind only on iOS (macOS now lets the route table decide, like Linux/Windows); broaden the iOS primary-interface selection from `enN`-only to any up, non-loopback, non-tunnel interface with a usable IPv4 (so it includes cellular `pdp_ipN`).

### 5. Drive the upstream handshake eagerly with a bounded retry (`eb3af51`)

**Problem:** for `udp+dtls` (and `tcp+tls`) `toURI.Dial()` returns a conn whose security handshake is **deferred to the first relay I/O**, and pion's lazy `Handshake()` runs under an **uncancellable `context.Background()`**. pion's UDP listener also keys conns by 5-tuple, so WireGuard's handshake-init retransmits from the same source port hit the *same* (stalled) conn and never re-enter the route handler. If the first upstream handshake stalls or fails, the relay is silently dark and stays dark until a full client reconnect — a "first connect dark, second attempt works" symptom (fatal on iOS, where netx lives inside the tunnel-scoped extension with no app-level recovery while backgrounded).

**Solution:** in `runTun`'s route handler, assert the deferred-handshake interface (`HandshakeContext(ctx)`) on the dialed conn and drive the handshake **eagerly under a bounded, cancellable per-attempt context**, with a bounded retry (3 attempts, 4 s each, 250 ms backoff). A stalled/failed first handshake becomes a fast, retryable dial error instead of a permanent dark relay. `ctx` cancellation (interrupt) aborts the loop and backoff immediately; the Darwin `dialControl` (IP_BOUND_IF) is re-applied on every attempt; AES-GCM/frame/plain conns don't implement the interface and no-op (they have no blocking handshake). Verified on-device (iOS): cold connects now establish on the first attempt.
